### PR TITLE
increase input font size to 16px to prevent mobile zoom.

### DIFF
--- a/src/alf/atoms.ts
+++ b/src/alf/atoms.ts
@@ -2,6 +2,7 @@ import {type StyleProp, type ViewStyle} from 'react-native'
 import {atoms as baseAtoms} from '@bsky.app/alf'
 
 import {CARD_ASPECT_RATIO} from '#/lib/constants'
+import * as tokens from '#/alf/tokens'
 import {native, platform, web} from '#/alf/util/platform'
 import * as Layout from '#/components/Layout'
 
@@ -9,6 +10,14 @@ const EXP_CURVE = 'cubic-bezier(0.16, 1, 0.3, 1)'
 
 export const atoms = {
   ...baseAtoms,
+
+  // Eurosky fork: text size for inputs
+  // A 16px minimum keeps mobile browsers from
+  // auto-zooming when an input is focused.
+  text_input: {
+    fontSize: tokens.inputMinFontSize,
+    letterSpacing: tokens.TRACKING,
+  },
 
   h_full_vh: web({
     height: '100vh',

--- a/src/alf/tokens.ts
+++ b/src/alf/tokens.ts
@@ -5,6 +5,11 @@ import {EUROSKY_GRADIENTS} from '#/config/eurosky-theme'
 
 export * from '@bsky.app/alf/dist/tokens'
 
+// Eurosky fork: minimum font size for text inputs.
+// Mobile browsers auto-zoom when a focused input renders below 16px,
+// so inputs never go under this size.
+export const inputMinFontSize = 16
+
 export const color = {
   temp_purple: tokens.labelerColor.purple,
   temp_purple_dark: tokens.labelerColor.purple_dark,

--- a/src/components/ProgressGuide/FollowDialog.tsx
+++ b/src/components/ProgressGuide/FollowDialog.tsx
@@ -710,7 +710,7 @@ function SearchInput({
         onChangeText={onChangeText}
         onFocus={onFocus}
         onBlur={onBlur}
-        style={[a.flex_1, a.py_md, a.text_md, t.atoms.text]}
+        style={[a.flex_1, a.py_md, a.text_input, t.atoms.text]}
         placeholderTextColor={t.palette.contrast_500}
         keyboardAppearance={t.name === 'light' ? 'light' : 'dark'}
         returnKeyType="search"

--- a/src/components/dialogs/SearchablePeopleList.tsx
+++ b/src/components/dialogs/SearchablePeopleList.tsx
@@ -674,7 +674,7 @@ function SearchInput({
         onChangeText={onChangeText}
         onFocus={onFocus}
         onBlur={onBlur}
-        style={[a.flex_1, a.py_md, a.text_md, t.atoms.text]}
+        style={[a.flex_1, a.py_md, a.text_input, t.atoms.text]}
         placeholderTextColor={t.palette.contrast_500}
         keyboardAppearance={t.name === 'light' ? 'light' : 'dark'}
         returnKeyType="search"

--- a/src/components/dms/components/UserSearchInput.tsx
+++ b/src/components/dms/components/UserSearchInput.tsx
@@ -45,7 +45,7 @@ export function UserSearchInput({
         onChangeText={onChangeText}
         onFocus={onFocus}
         onBlur={onBlur}
-        style={[a.flex_1, a.py_md, a.text_md, t.atoms.text]}
+        style={[a.flex_1, a.py_md, a.text_input, t.atoms.text]}
         placeholderTextColor={t.palette.contrast_500}
         keyboardAppearance={t.name === 'light' ? 'light' : 'dark'}
         returnKeyType="search"

--- a/src/components/forms/AutosizedTextarea.tsx
+++ b/src/components/forms/AutosizedTextarea.tsx
@@ -35,7 +35,7 @@ export function AutosizedTextarea({
   const {style, minInputHeight, maxInputHeight, verticalContentPadding} =
     useMemo(() => {
       const normalizedStyles = normalizeTextStyles(
-        [a.text_md, a.leading_snug, t.atoms.text, outerStyle],
+        [a.text_input, a.leading_snug, t.atoms.text, outerStyle],
         {
           fontScale: fonts.scaleMultiplier,
           fontFamily: fonts.family,

--- a/src/components/forms/TextField.tsx
+++ b/src/components/forms/TextField.tsx
@@ -207,12 +207,12 @@ export function createInput(Component: typeof TextInput) {
       a.relative,
       a.z_20,
       a.flex_1,
-      a.text_md,
+      a.text_input,
       t.atoms.text,
       a.px_xs,
       {
         // paddingVertical doesn't work w/multiline - esb
-        lineHeight: a.text_md.fontSize * 1.2,
+        lineHeight: a.text_input.fontSize * 1.2,
         textAlignVertical: rest.multiline ? 'top' : undefined,
         minHeight: rest.multiline ? 80 : undefined,
         minWidth: 0,
@@ -436,8 +436,8 @@ export function GhostText({
       <Text
         style={[
           {color: 'transparent'},
-          a.text_md,
-          {lineHeight: a.text_md.fontSize * 1.1875},
+          a.text_input,
+          {lineHeight: a.text_input.fontSize * 1.1875},
           a.w_full,
         ]}
         numberOfLines={1}>
@@ -445,8 +445,8 @@ export function GhostText({
         <Text
           style={[
             t.atoms.text_contrast_low,
-            a.text_md,
-            {lineHeight: a.text_md.fontSize * 1.1875},
+            a.text_input,
+            {lineHeight: a.text_input.fontSize * 1.1875},
           ]}>
           {value}
         </Text>

--- a/src/screens/Messages/components/MessageInput.tsx
+++ b/src/screens/Messages/components/MessageInput.tsx
@@ -197,7 +197,7 @@ export function MessageInput({
               {flexBasis: 'auto', minHeight: MIN_HEIGHT},
               a.flex_shrink_0,
               a.flex_grow,
-              a.text_md,
+              a.text_input,
               a.px_lg,
               t.atoms.text,
               platform({


### PR DESCRIPTION
add a text_input atom following the same pattern as other font sizes, backed by a new inputMinFontSize token.