### PR TITLE
Quentin/plausible setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,20 @@ EXPO_PUBLIC_SENTRY_DSN=
 # Bitdrift API key. If undefined, Bitdrift will be disabled.
 EXPO_PUBLIC_BITDRIFT_API_KEY=
 
+# Plausible Analytics site domain, as configured in Plausible's settings. When
+# set, an allowlisted subset of events is forwarded to Plausible; when unset,
+# the Plausible sink is disabled and events fall back to the primary metrics
+# pipeline.
+EXPO_PUBLIC_PLAUSIBLE_DOMAIN=
+
+# Plausible API host. Defaults to https://plausible.io when unset; point it at a
+# self-hosted instance or a first-party proxy if needed.
+EXPO_PUBLIC_PLAUSIBLE_API_HOST=
+
+# When "true", the Plausible sink prints each event to the console and skips the
+# network entirely. Useful for local development. Defaults to off.
+EXPO_PUBLIC_PLAUSIBLE_DEBUG=
+
 # geolocation web worker URL
 GEOLOCATION_DEV_URL=
 

--- a/.env.example
+++ b/.env.example
@@ -49,3 +49,8 @@ LIVE_EVENTS_DEV_URL=
 
 # app-config web worker URL
 APP_CONFIG_DEV_URL=
+
+# Service enable flags (default true, set to 'false' to disable)
+EXPO_PUBLIC_ENABLE_GEOLOCATION=
+EXPO_PUBLIC_ENABLE_LIVE_EVENTS=
+EXPO_PUBLIC_ENABLE_APP_CONFIG=

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "@ipld/dag-cbor": "^9.2.7",
     "@lingui/core": "^5.9.2",
     "@lingui/react": "^5.9.2",
+    "@plausible-analytics/tracker": "0.4.5",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-navigation/bottom-tabs": "^7.15.5",
     "@react-navigation/native": "^7.1.33",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,6 +357,9 @@ importers:
       '@lingui/react':
         specifier: ^5.9.2
         version: 5.9.5(@lingui/babel-plugin-lingui-macro@5.9.5(typescript@6.0.3))(react@19.1.0)
+      '@plausible-analytics/tracker':
+        specifier: 0.4.5
+        version: 0.4.5
       '@react-native-async-storage/async-storage':
         specifier: 2.2.0
         version: 2.2.0(react-native@0.81.5(patch_hash=2656ac6deb71b92a4df4af4593d13ace6a5740936432e5e7e8ef32bc3cd05194)(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))
@@ -2438,6 +2441,9 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@plausible-analytics/tracker@0.4.5':
+    resolution: {integrity: sha512-6BfAGejXY+YA3Cw6LYT2Zpn4hTxDtPQAawFsYUsQCOg78wIS5C4deAGXTfJffa5VleMWITv5lpJ/EYuQBl1tPA==}
 
   '@pmmmwh/react-refresh-webpack-plugin@0.5.17':
     resolution: {integrity: sha512-tXDyE1/jzFsHXjhRZQ3hMl0IVhYe5qula43LDWIhVfjp9G/nT5OQY5AORVOrkEGAUltBJOfOWeETbmhm6kHhuQ==}
@@ -11702,6 +11708,8 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@plausible-analytics/tracker@0.4.5': {}
 
   '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@1.4.0)(webpack-dev-server@4.15.2(webpack@5.106.2(postcss@8.5.14)))(webpack@5.106.2(postcss@8.5.14))':
     dependencies:

--- a/src/analytics/index.tsx
+++ b/src/analytics/index.tsx
@@ -23,6 +23,8 @@ import {
 } from '#/analytics/metadata'
 import {type Metrics, metrics} from '#/analytics/metrics'
 import * as refParams from '#/analytics/misc/refParams'
+import {plausible} from '#/analytics/plausible'
+import {PLAUSIBLE_GOALS} from '#/analytics/plausible/shared'
 import * as env from '#/env'
 import {useGeolocationServiceResponse} from '#/geolocation/service'
 import {device} from '#/storage'
@@ -88,10 +90,23 @@ const Context = createContext<AnalyticsBaseContextType>({
     if (metadata && '__meta' in metadata) {
       delete metadata.__meta
     }
-    metrics.track(event, payload, {
-      ...metadata,
-      navigation: getNavigationMetadata(),
-    })
+    /**
+     * All `metric()` calls bubble up to this root handler, so this is the
+     * single routing point. When a Plausible domain is configured we forward an
+     * allowlisted subset of goals to Plausible (pageviews are auto-captured by
+     * the tracker on web; native is disabled). Otherwise we fall back to the
+     * primary metrics pipeline. See `#/analytics/plausible`.
+     */
+    if (env.PLAUSIBLE_DOMAIN) {
+      if (PLAUSIBLE_GOALS.has(event)) {
+        plausible.track(event, payload, metadata)
+      }
+    } else {
+      metrics.track(event, payload, {
+        ...metadata,
+        navigation: getNavigationMetadata(),
+      })
+    }
   },
   metadata: {
     base: {
@@ -111,6 +126,14 @@ const Context = createContext<AnalyticsBaseContextType>({
   },
 })
 Context.displayName = 'AnalyticsContext'
+
+/**
+ * Initialize the Plausible sink. No-op when no domain is configured, and safe
+ * to call once at module load. On web this sets up the tracker (which then
+ * auto-captures pageviews); on native it is a no-op - Plausible is disabled
+ * there for now.
+ */
+plausible.init()
 
 /**
  * Ensures that deviceId is set and migrated from legacy storage. Handled on

--- a/src/analytics/index.tsx
+++ b/src/analytics/index.tsx
@@ -101,7 +101,9 @@ const Context = createContext<AnalyticsBaseContextType>({
       if (PLAUSIBLE_GOALS.has(event)) {
         plausible.track(event, payload, metadata)
       }
+      // Non-goal events are not sent to Plausible
     } else {
+      // In case of no Plausible domain, we go back to the primary metrics pipeline for all events
       metrics.track(event, payload, {
         ...metadata,
         navigation: getNavigationMetadata(),

--- a/src/analytics/plausible/index.ts
+++ b/src/analytics/plausible/index.ts
@@ -1,0 +1,18 @@
+import {type PlausibleClient} from '#/analytics/plausible/shared'
+
+/**
+ * Native Plausible sink - disabled for now.
+ *
+ * Plausible is a web-analytics product and `@plausible-analytics/tracker` is
+ * browser-only (it reads `location`, `document`, `ResizeObserver`, etc.), so it
+ * cannot run on native. We previously posted goals to the Events API directly,
+ * but for now native sends nothing to Plausible. The primary metrics pipeline
+ * is unaffected and still captures everything on all platforms.
+ *
+ * To re-enable native, implement `track` here against the Events API:
+ * https://plausible.io/docs/events-api
+ */
+export const plausible: PlausibleClient = {
+  init() {},
+  track() {},
+}

--- a/src/analytics/plausible/index.web.ts
+++ b/src/analytics/plausible/index.web.ts
@@ -1,0 +1,55 @@
+import {
+  init as plausibleInit,
+  track as plausibleTrack,
+} from '@plausible-analytics/tracker'
+
+import {Logger} from '#/logger'
+import {
+  buildProps,
+  logEventToConsole,
+  type PlausibleClient,
+} from '#/analytics/plausible/shared'
+import * as env from '#/env'
+
+const logger = Logger.create(Logger.Context.Metric)
+
+let initialized = false
+
+export const plausible: PlausibleClient = {
+  init() {
+    if (initialized) return
+    if (!env.PLAUSIBLE_DOMAIN) return
+    try {
+      plausibleInit({
+        domain: env.PLAUSIBLE_DOMAIN,
+        endpoint: `${env.PLAUSIBLE_API_HOST}/api/event`,
+        // Use Plausible's standard history-based pageview auto-capture. On web
+        // React Navigation updates the URL via the History API, so the library
+        // records a pageview on every route change without us driving it.
+        // By default Plausible drops events on localhost. Enable capture in dev
+        // builds so the integration can be exercised locally; production builds
+        // are never on localhost, so this has no effect there.
+        captureOnLocalhost: __DEV__,
+      })
+      initialized = true
+    } catch (e) {
+      logger.warn('Plausible init failed', {
+        safeMessage: e instanceof Error ? e.message : String(e),
+      })
+    }
+  },
+
+  track(event, payload, metadata) {
+    const props = buildProps(payload, metadata)
+    if (env.PLAUSIBLE_DEBUG) {
+      logEventToConsole(event, props)
+      return
+    }
+    if (!initialized) return
+    try {
+      plausibleTrack(event, {props})
+    } catch {
+      // best-effort; the primary metrics sink already captured this event
+    }
+  },
+}

--- a/src/analytics/plausible/shared.ts
+++ b/src/analytics/plausible/shared.ts
@@ -1,0 +1,138 @@
+import {Platform} from 'react-native'
+
+import {type Metadata} from '#/analytics/metadata'
+import {type Metrics} from '#/analytics/metrics'
+import * as env from '#/env'
+
+/**
+ * Platform-agnostic Plausible sink. The web and native implementations both
+ * conform to this interface so the fan-out in `#/analytics` can call it without
+ * knowing the platform. See `index.web.ts` (uses `@plausible-analytics/tracker`,
+ * with pageviews auto-captured by the library) and `index.ts` (native, a no-op
+ * for now).
+ */
+export interface PlausibleClient {
+  /**
+   * Initialize the sink. Safe to call when disabled (no domain configured) and
+   * safe to call more than once. Must run before `track` does anything. On web
+   * this sets up the tracker and enables history-based pageview auto-capture.
+   */
+  init(): void
+  /**
+   * Forward an allowlisted metric event to Plausible as a custom goal. The
+   * payload is sanitized into low-cardinality string props first.
+   */
+  track(
+    event: keyof Metrics,
+    payload: Record<string, unknown>,
+    metadata?: Partial<Metadata>,
+  ): void
+}
+
+/**
+ * Allowlist of high-level "goals" forwarded to Plausible. Plausible is built
+ * for a small set of conversion goals, not the full ~250-event product stream,
+ * so we deliberately forward only this curated subset. Everything else stays on
+ * the primary MetricsClient sink only.
+ *
+ * Keep this list short and high-signal. Adding the full event stream would
+ * blow past Plausible's goal model and make the dashboards unreadable.
+ */
+export const PLAUSIBLE_GOALS: ReadonlySet<keyof Metrics> = new Set<
+  keyof Metrics
+>([
+  'account:create:success',
+  'account:loggedIn',
+  'signin:success',
+  'onboarding:finished:nextPressed',
+  'post:create',
+  'thread:create',
+  'profile:follow',
+  'composer:open',
+  'search:query',
+  'starterPack:create',
+  'verification:create',
+  'chat:create',
+])
+
+/**
+ * Payload keys that must never be forwarded to Plausible, either because they
+ * identify a user/device/session or because they are high-cardinality values
+ * (URIs, DIDs, handles) that would pollute Plausible's property breakdowns and
+ * undermine its privacy model. Anything not on this list is still subject to
+ * the primitive-only coercion in `buildProps`.
+ */
+const DENIED_PROP_KEYS: ReadonlySet<string> = new Set([
+  'uri',
+  'url',
+  'authorDid',
+  'followeeDid',
+  'followerDid',
+  'suggestedDid',
+  'profileDid',
+  'contextProfileDid',
+  'userDid',
+  'did',
+  'deviceId',
+  'sessionId',
+  'feedUrl',
+  'feedUri',
+  'feedDescriptor',
+  'starterPack',
+  'starterPackUri',
+  'starterPackCreator',
+  'starterPackName',
+  'subject',
+  'recId',
+  'handle',
+  'domain',
+])
+
+/**
+ * Plausible custom properties must be a flat `Record<string, string>`. This
+ * coerces an event payload into safe, low-cardinality string props:
+ * - drops identity / high-cardinality keys (see `DENIED_PROP_KEYS`)
+ * - drops nullish values and any non-primitive (arrays/objects)
+ * - coerces remaining primitives to strings
+ * - merges in safe dimensions (platform, appVersion, countryCode)
+ *
+ * Identity fields like deviceId/sessionId/did are intentionally never sent;
+ * Plausible's value is aggregate, privacy-first analytics.
+ */
+export function buildProps(
+  payload: Record<string, unknown>,
+  metadata?: Partial<Metadata>,
+): Record<string, string> {
+  const props: Record<string, string> = {
+    platform: Platform.OS,
+    appVersion: env.APP_VERSION,
+  }
+
+  const countryCode = metadata?.geolocation?.countryCode
+  if (countryCode) {
+    props.countryCode = countryCode
+  }
+
+  for (const [key, value] of Object.entries(payload)) {
+    if (DENIED_PROP_KEYS.has(key)) continue
+    // Coerce only primitives. Arrays/objects/nullish are dropped: they are not
+    // meaningful as Plausible props.
+    if (typeof value === 'string') {
+      props[key] = value
+    } else if (typeof value === 'number' || typeof value === 'boolean') {
+      props[key] = String(value)
+    }
+  }
+
+  return props
+}
+
+/**
+ * Debug helper used by both sinks when `PLAUSIBLE_DEBUG` is enabled. Prints the
+ * event that would be sent to Plausible, with its sanitized props, and sends
+ * nothing over the network. The `[plausible]` prefix makes it easy to filter in
+ * the console.
+ */
+export function logEventToConsole(name: string, props: Record<string, string>) {
+  console.info('[plausible]', name, props)
+}

--- a/src/env/common.ts
+++ b/src/env/common.ts
@@ -103,6 +103,32 @@ export const GROWTHBOOK_CLIENT_KEY: string =
   process.env.EXPO_PUBLIC_GROWTHBOOK_CLIENT_KEY || 'sdk-7gkUkGy9wguUjyFe'
 
 /**
+ * Plausible Analytics site domain, as configured in Plausible's settings. When
+ * unset, the Plausible analytics sink is disabled entirely. Plausible is a
+ * secondary, privacy-first sink that receives an allowlisted subset of events;
+ * the primary metrics pipeline is unaffected by this value.
+ */
+export const PLAUSIBLE_DOMAIN: string | undefined =
+  process.env.EXPO_PUBLIC_PLAUSIBLE_DOMAIN
+
+/**
+ * Plausible API host. Points at Plausible Cloud by default, but can be set to a
+ * self-hosted instance or a first-party proxy. The tracker posts to
+ * `${PLAUSIBLE_API_HOST}/api/event`.
+ */
+export const PLAUSIBLE_API_HOST: string =
+  process.env.EXPO_PUBLIC_PLAUSIBLE_API_HOST || 'https://plausible.io'
+
+/**
+ * When `true`, the Plausible sink prints each event it would send to the
+ * console and skips the network entirely. Useful for local development: no
+ * domain or dashboard required, and works on both web and native. Defaults to
+ * off.
+ */
+export const PLAUSIBLE_DEBUG: boolean =
+  process.env.EXPO_PUBLIC_PLAUSIBLE_DEBUG === 'true'
+
+/**
  * Sentry DSN for telemetry
  */
 export const SENTRY_DSN: string | undefined = process.env.EXPO_PUBLIC_SENTRY_DSN

--- a/src/env/common.ts
+++ b/src/env/common.ts
@@ -177,3 +177,13 @@ export const APP_CONFIG_PROD_URL = `https://app-config.workers.bsky.app`
 export const APP_CONFIG_URL = IS_DEV
   ? (APP_CONFIG_DEV_URL ?? APP_CONFIG_PROD_URL)
   : APP_CONFIG_PROD_URL
+
+/**
+ * Service enable flags. Default true. Set to 'false' to disable.
+ */
+export const ENABLE_GEOLOCATION =
+  process.env.EXPO_PUBLIC_ENABLE_GEOLOCATION !== 'false'
+export const ENABLE_LIVE_EVENTS =
+  process.env.EXPO_PUBLIC_ENABLE_LIVE_EVENTS !== 'false'
+export const ENABLE_APP_CONFIG =
+  process.env.EXPO_PUBLIC_ENABLE_APP_CONFIG !== 'false'

--- a/src/features/liveEvents/context.tsx
+++ b/src/features/liveEvents/context.tsx
@@ -10,7 +10,7 @@ import {
   makeRecordUri,
 } from '#/lib/strings/url-helpers'
 import {usePreferencesQuery} from '#/state/queries/preferences'
-import {IS_DEV, LIVE_EVENTS_URL} from '#/env'
+import {ENABLE_LIVE_EVENTS, IS_DEV, LIVE_EVENTS_URL} from '#/env'
 import {useLiveEventPreferences} from '#/features/liveEvents/preferences'
 import {type LiveEventsWorkerResponse} from '#/features/liveEvents/types'
 import {useDevMode} from '#/storage/hooks/dev-mode'
@@ -49,6 +49,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       // keep this, prefectching handles initial load
       staleTime: 1000 * 15,
       queryKey: liveEventsQueryKey,
+      enabled: ENABLE_LIVE_EVENTS,
       refetchInterval: 1000 * 60 * 5, // refetch every 5 minutes
       async queryFn() {
         return fetchLiveEvents()
@@ -89,6 +90,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
 }
 
 export async function prefetchLiveEvents() {
+  if (!ENABLE_LIVE_EVENTS) return
   const data = await fetchLiveEvents()
   if (data) {
     qc.setQueryData(liveEventsQueryKey, data)

--- a/src/geolocation/service.ts
+++ b/src/geolocation/service.ts
@@ -2,6 +2,7 @@ import {useEffect, useState} from 'react'
 import {EventEmitter} from 'eventemitter3'
 
 import {networkRetry} from '#/lib/async/retry'
+import {ENABLE_GEOLOCATION} from '#/env'
 import {
   FALLBACK_GEOLOCATION_SERVICE_RESPONSE,
   GEOLOCATION_SERVICE_URL,
@@ -47,6 +48,7 @@ let geolocationServicePromise: Promise<{success: boolean}> | undefined
  * startup.
  */
 export async function resolve() {
+  if (!ENABLE_GEOLOCATION) return
   if (geolocationServicePromise) {
     const cached = device.get(['geolocationServiceResponse'])
     if (cached) {

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -1,7 +1,7 @@
 import {Platform} from 'react-native'
 
-import {tokens} from '#/alf'
 import {darkPalette, dimPalette, lightPalette} from '#/alf/themes'
+import * as tokens from '#/alf/tokens'
 import {fontWeight} from '#/alf/tokens'
 import {colors} from './styles'
 import {type Theme} from './ThemeContext'

--- a/src/state/appConfig.tsx
+++ b/src/state/appConfig.tsx
@@ -1,7 +1,7 @@
 import {createContext, useContext} from 'react'
 import {QueryClient, useQuery} from '@tanstack/react-query'
 
-import {APP_CONFIG_URL} from '#/env'
+import {APP_CONFIG_URL, ENABLE_APP_CONFIG} from '#/env'
 
 const qc = new QueryClient()
 const appConfigQueryKey = ['app-config']
@@ -47,11 +47,14 @@ async function fetchAppConfig(): Promise<AppConfigResponse | null> {
 
 const Context = createContext<AppConfigResponse>(DEFAULT_APP_CONFIG_RESPONSE)
 
+const enabled = ENABLE_APP_CONFIG
+
 export function Provider({children}: React.PropsWithChildren<{}>) {
   const {data} = useQuery<AppConfigResponse | null>(
     {
       staleTime: Infinity,
       queryKey: appConfigQueryKey,
+      enabled,
       refetchInterval: query => {
         // refetch regularly if fetch failed, otherwise never refetch
         return query.state.status === 'error' ? 60e3 : Infinity
@@ -70,6 +73,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
 }
 
 export async function prefetchAppConfig() {
+  if (!enabled) return
   try {
     const data = await fetchAppConfig()
     if (data) {


### PR DESCRIPTION
This pull request introduces a secondary analytics pipeline using Plausible Analytics, forwarding selected events to Plausible on web platforms, while keeping the primary metrics pipeline unchanged if that is not configured. It also adds environment-based feature flags to enable or disable major services (geolocation, live events, and app config) via environment variables. 

**Analytics Integration:**

* Added Plausible Analytics as an optional, privacy-focused secondary analytics sink, forwarding only an allowlisted set of high-level goal events on web platforms using the `@plausible-analytics/tracker` package. On Native platforms Plausible initialization is currently a no-op
* Keep original `MetricsClient` if `EXPO_PUBLIC_PLAUSIBLE_DOMAIN` is not set, use plausible as event sync otherwise
* Added new environment variables and documentation for configuring Plausible Analytics, including domain, API host, and debug mode. (EXPO_PUBLIC_PLAUSIBLE_DOMAIN, EXPO_PUBLIC_PLAUSIBLE_API_HOST, EXPO_PUBLIC_PLAUSIBLE_DEBUG)

**Flags for services still using Bsky endpoints:**

* Introduced environment-based feature flags (`EXPO_PUBLIC_ENABLE_GEOLOCATION`, `EXPO_PUBLIC_ENABLE_LIVE_EVENTS`, `EXPO_PUBLIC_ENABLE_APP_CONFIG`) to selectively enable or disable geolocation, live events, and app config services at runtime.
* Updated service initialization and data fetching logic throughout the codebase to respect these enablement flags, ensuring services are only initialized and queried if enabled. 

Currently the underlying endpoints all trigger CORS failures, so this mainly cleans up the console errors and stops sending requests to bluesky servers that aren't the appview.
