### PR TITLE
Quentin/plausible env deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,7 @@ LIVE_EVENTS_DEV_URL=
 APP_CONFIG_DEV_URL=
 
 # Service enable flags (default true, set to 'false' to disable)
-EXPO_PUBLIC_ENABLE_GEOLOCATION=
-EXPO_PUBLIC_ENABLE_LIVE_EVENTS=
-EXPO_PUBLIC_ENABLE_APP_CONFIG=
+# Eurosky defaults disable these worker-backed services in standard builds.
+EXPO_PUBLIC_ENABLE_GEOLOCATION=false
+EXPO_PUBLIC_ENABLE_LIVE_EVENTS=false
+EXPO_PUBLIC_ENABLE_APP_CONFIG=false

--- a/.github/workflows/deploy-web-bunny.yml
+++ b/.github/workflows/deploy-web-bunny.yml
@@ -39,6 +39,11 @@ jobs:
       # uses --frozen-lockfile.
       - name: Build web
         run: bash ./pages_build.sh
+        env:
+          EXPO_PUBLIC_ENABLE_GEOLOCATION: 'false'
+          EXPO_PUBLIC_ENABLE_LIVE_EVENTS: 'false'
+          EXPO_PUBLIC_ENABLE_APP_CONFIG: 'false'
+          EXPO_PUBLIC_PLAUSIBLE_DOMAIN: mu.social
       - name: Upload to Bunny + purge cache
         run: bash ./bunny_upload.sh
         env:

--- a/oauth-worker/test.mjs
+++ b/oauth-worker/test.mjs
@@ -35,7 +35,14 @@ const ALLOWED_ORIGIN = /ALLOWED_ORIGIN\s*=\s*"([^"]+)"/.exec(toml)?.[1]
 // The public key the Worker's private counterpart must match (shared kid).
 const publicJwks = JSON.parse(
   readFileSync(
-    join(here, '..', 'eurosky-social-app', 'src', 'config', 'oauth.public-jwks.json'),
+    join(
+      here,
+      '..',
+      'eurosky-social-app',
+      'src',
+      'config',
+      'oauth.public-jwks.json',
+    ),
     'utf8',
   ),
 )
@@ -185,7 +192,12 @@ async function main() {
   // HIGH-2: injected header params + extra claims must be STRIPPED by the
   // reconstructing minter (and a bogus caller kid ignored, not echoed).
   const inj = await call({
-    header: {...validHeader(), kid: 'attacker-kid', injected_hdr: 'x', crit: ['x']},
+    header: {
+      ...validHeader(),
+      kid: 'attacker-kid',
+      injected_hdr: 'x',
+      crit: ['x'],
+    },
     payload: validPayload({injected_claim: 'y', scope: 'transition:generic'}),
   })
   if (inj.status === 200 && inj.json?.jws) {
@@ -217,9 +229,18 @@ async function main() {
     ['wrong sub -> 400', {payload: validPayload({sub: 'https://evil'})}],
     ['lifetime > 300s -> 400', {payload: validPayload({exp: now() + 3600})}],
     ['non-https aud -> 400', {payload: validPayload({aud: 'http://x'})}],
-    ['aud with path -> 400', {payload: validPayload({aud: 'https://bsky.social/x'})}],
-    ['aud with query -> 400', {payload: validPayload({aud: 'https://bsky.social/?a=1'})}],
-    ['aud with userinfo -> 400', {payload: validPayload({aud: 'https://u@bsky.social'})}],
+    [
+      'aud with path -> 400',
+      {payload: validPayload({aud: 'https://bsky.social/x'})},
+    ],
+    [
+      'aud with query -> 400',
+      {payload: validPayload({aud: 'https://bsky.social/?a=1'})},
+    ],
+    [
+      'aud with userinfo -> 400',
+      {payload: validPayload({aud: 'https://u@bsky.social'})},
+    ],
     ['missing jti -> 400', {payload: validPayload({jti: undefined})}],
     ['alg != ES256 -> 400', {header: {...validHeader(), alg: 'HS256'}}],
   ]
@@ -240,7 +261,9 @@ function validPayloadEnvelope() {
 }
 
 function summarize(skipped) {
-  console.log(`\n${passed} passed, ${failed} failed${skipped ? ' (signing tests skipped)' : ''}`)
+  console.log(
+    `\n${passed} passed, ${failed} failed${skipped ? ' (signing tests skipped)' : ''}`,
+  )
   process.exit(failed ? 1 : 0)
 }
 

--- a/pages_build.sh
+++ b/pages_build.sh
@@ -21,6 +21,17 @@
 #   bash -lc '. "$HOME/.nvm/nvm.sh"; nvm use 24; ./pages_build.sh'
 set -euo pipefail
 
+# Eurosky defaults for web builds. These can still be overridden by explicitly
+# exporting different values in CI or local shells.
+: "${EXPO_PUBLIC_ENABLE_GEOLOCATION:=false}"
+: "${EXPO_PUBLIC_ENABLE_LIVE_EVENTS:=false}"
+: "${EXPO_PUBLIC_ENABLE_APP_CONFIG:=false}"
+: "${EXPO_PUBLIC_PLAUSIBLE_DOMAIN:=mu.social}"
+export EXPO_PUBLIC_ENABLE_GEOLOCATION
+export EXPO_PUBLIC_ENABLE_LIVE_EVENTS
+export EXPO_PUBLIC_ENABLE_APP_CONFIG
+export EXPO_PUBLIC_PLAUSIBLE_DOMAIN
+
 # Use frozen lockfile in CI (mirrors GitHub Actions); allow regeneration locally.
 if [[ -n "${CI:-}" ]]; then
   pnpm install --frozen-lockfile

--- a/src/state/session/oauth-web-client.ts
+++ b/src/state/session/oauth-web-client.ts
@@ -49,7 +49,7 @@ import {createOAuthRemoteKey} from './oauthRemoteKey'
 export interface WebOAuthClient {
   signIn(input: string, options?: AuthorizeOptions): Promise<void>
   init(): Promise<{session: OAuthSession; state?: string | null} | undefined>
-  restore(sub: string, refresh?: boolean | 'auto'): Promise<OAuthSession>
+  restore(sub: string, refresh?: boolean): Promise<OAuthSession>
 }
 
 function isLoopback(): boolean {

--- a/src/state/session/oauthBrowserBackend.ts
+++ b/src/state/session/oauthBrowserBackend.ts
@@ -47,7 +47,12 @@ export function createEuroskyOAuthRuntime(): RuntimeImplementation {
     createKey: algs => WebcryptoKey.generate(algs),
     getRandomValues: len => crypto.getRandomValues(new Uint8Array(len)),
     async digest(data, {name}) {
-      const buf = await crypto.subtle.digest(`SHA-${name.slice(3)}`, data)
+      // Normalize to a concrete ArrayBuffer-backed view for TS 6 BufferSource.
+      const digestInput = Uint8Array.from(data)
+      const buf = await crypto.subtle.digest(
+        `SHA-${name.slice(3)}`,
+        digestInput,
+      )
       return new Uint8Array(buf)
     },
     requestLock,
@@ -181,7 +186,7 @@ function createKeyStore<V extends {dpopKey: Key}>(
         await del(key)
         return undefined
       }
-      return {...rest, dpopKey: await decodeKey(dpopKey)} as V
+      return {...rest, dpopKey: await decodeKey(dpopKey)} as unknown as V
     },
     async set(key: string, value: V): Promise<void> {
       const {dpopKey, ...rest} = value


### PR DESCRIPTION
This pull request adds default values for deploy to mu.social and disabling unwanted functionalities

**Environment configuration improvements:**

* Default values for `EXPO_PUBLIC_ENABLE_GEOLOCATION`, `EXPO_PUBLIC_ENABLE_LIVE_EVENTS`, and `EXPO_PUBLIC_ENABLE_APP_CONFIG` are now set to `'false'` in `.env.example`, making it clear these services are disabled by default for standard builds.
* The `pages_build.sh` script now explicitly sets and exports these environment variables (as well as `EXPO_PUBLIC_PLAUSIBLE_DOMAIN`) with sensible defaults, ensuring consistent behavior in local and CI builds.
* The web deployment GitHub Actions workflow (`deploy-web-bunny.yml`) now sets the same environment variables during the build step, aligning CI/CD with local development and build scripts.

**Fix linting issues**

Other changes are related to linting failures