### PR TITLE
Update focus to Mu Social and clarify Eurosky operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Bluesky Social App
+# Mu Social App
 
-Welcome friends! This is the codebase for the Bluesky Social app.
+Welcome friends! This is the codebase for the Mu social application.
 
 Get the app itself:
 
@@ -23,7 +23,7 @@ The Authenticated Transfer Protocol ("AT Protocol" or "atproto") is a decentrali
 - [Protocol Specifications](https://atproto.com/specs/atp)
 - [Blogpost on self-authenticating data structures](https://bsky.social/about/blog/3-6-2022-a-self-authenticating-social-protocol)
 
-The Bluesky Social application encompasses a set of schemas and APIs built in the overall AT Protocol framework. The namespace for these "Lexicons" is `app.bsky.*`.
+The Mu application encompasses a set of schemas and APIs built in the overall AT Protocol framework. The namespace for these "Lexicons" is `app.bsky.*`.
 
 ## Contributions
 
@@ -54,7 +54,7 @@ You have our blessing 🪄✨ to fork this application! However, it's very impor
 
 Please be sure to:
 
-- Change all branding in the repository and UI to clearly differentiate from Bluesky.
+- Change all branding in the repository and UI to clearly differentiate from Mu.
 - Change any support links (feedback, email, terms of service, etc) to your own systems.
 - Replace any analytics or error-collection systems with your own so we don't get super confused.
 
@@ -64,7 +64,7 @@ If you discover any security issues, please send an email to security@bsky.app. 
 
 ## Are you a developer interested in building on atproto?
 
-Bluesky is an open social network built on the AT Protocol, a flexible technology that will never lock developers out of the ecosystems that they help build. With atproto, third-party integration can be as seamless as first-party through custom feeds, federated services, clients, and more.
+Mu is an open social network built on the AT Protocol, a flexible technology that will never lock developers out of the ecosystems that they help build. With atproto, third-party integration can be as seamless as first-party through custom feeds, federated services, clients, and more.
 
 ## License (MIT)
 
@@ -74,4 +74,4 @@ Bluesky Social PBC has committed to a software patent non-aggression pledge. For
 
 ## P.S.
 
-We ❤️ you and all of the ways you support us. Thank you for making Bluesky a great place!
+We ❤️ you and all of the ways you support us. Thank you for making Mu a great place!

--- a/README.md
+++ b/README.md
@@ -1,77 +1,38 @@
-# Mu Social App
+# Mu Social
 
-Welcome friends! This is the codebase for the Mu social application.
+Mu ([mu.social](https://mu.social)) is a web-app-only social application operated by Eurosky ([eurosky.tech](https://eurosky.tech)). 
 
-Get the app itself:
+This repository is a downstream fork of the [Bluesky social application](https://github.com/bluesky-social/social-app). While it maintains compatibility with the AT Protocol, it is specifically optimized and branded for the Mu web experience.
 
-- **Web: [bsky.app](https://bsky.app)**
-- **iOS: [App Store](https://apps.apple.com/us/app/bluesky-social/id6444370199)**
-- **Android: [Play Store](https://play.google.com/store/apps/details?id=xyz.blueskyweb.app)**
+## Relationship with Upstream
+
+Mu is maintained by Eurosky and is not affiliated with Bluesky Social, PBC. This project tracks upstream changes from the original repository while applying custom branding, configuration, and web-specific optimizations. For the original application and mobile versions, please refer to the [official Bluesky repository](https://github.com/bluesky-social/social-app).
 
 ## Development Resources
 
-This is a [React Native](https://reactnative.dev/) application, written in the TypeScript programming language. It builds on the `atproto` TypeScript packages (like [`@atproto/api`](https://www.npmjs.com/package/@atproto/api)), which are also open source, but in [a different git repository](https://github.com/bluesky-social/atproto).
+This is a [React Native](https://reactnative.dev/) application, written in the TypeScript programming language, utilizing React Native Web for the Mu platform. It builds on the `atproto` TypeScript packages (like [`@atproto/api`](https://www.npmjs.com/package/@atproto/api)), which are also open source, but in [a different git repository](https://github.com/bluesky-social/atproto).
 
-There is a small amount of Go language source code (in `./bskyweb/`), for a web service that returns the React Native Web application.
+There is a small amount of Go language source code (in `./bskyweb/`), for the web service that serves the application.
 
 The [Build Instructions](./docs/build.md) are a good place to get started with the app itself.
 
-The Authenticated Transfer Protocol ("AT Protocol" or "atproto") is a decentralized social media protocol. You don't *need* to understand AT Protocol to work with this application, but it can help. Learn more at:
+The Authenticated Transfer Protocol ("AT Protocol" or "atproto") is a decentralized social media protocol. Learn more at:
 
 - [Overview and Guides](https://atproto.com/guides/overview)
-- [GitHub Discussions](https://github.com/bluesky-social/atproto/discussions) 👈 Great place to ask questions
 - [Protocol Specifications](https://atproto.com/specs/atp)
-- [Blogpost on self-authenticating data structures](https://bsky.social/about/blog/3-6-2022-a-self-authenticating-social-protocol)
-
-The Mu application encompasses a set of schemas and APIs built in the overall AT Protocol framework. The namespace for these "Lexicons" is `app.bsky.*`.
 
 ## Contributions
 
-> [!NOTE]
-> While we do accept contributions, we prioritize high quality issues and pull requests. Adhering to the below guidelines will ensure a more timely review.
+Eurosky accepts contributions that improve the Mu web experience. Please follow these guidelines:
 
-**Rules:**
+- **Focus:** We prioritize high-quality issues and pull requests that align with our web-only focus.
+- **Discussion:** Open an issue to discuss significant changes before submitting a PR.
+- **Branding:** Ensure all contributions respect the Mu branding guidelines.
 
-- We may not respond to your issue or PR.
-- We may close an issue or PR without much feedback.
-- We may lock discussions or contributions if our attention is getting DDOSed.
-- We're not going to provide support for build issues.
+## Security Disclosures
 
-**Guidelines:**
-
-- Check for existing issues before filing a new one please.
-- Open an issue and give some time for discussion before submitting a PR.
-- Stay away from PRs like...
-  - Changing "Post" to "Skeet."
-  - Refactoring the codebase, e.g., to replace React Query with Redux Toolkit or something.
-  - Adding entirely new features without prior discussion. 
-
-Remember, we serve a wide community of users. Our day-to-day involves us constantly asking "which top priority is our top priority." If you submit well-written PRs that solve problems concisely, that's an awesome contribution. Otherwise, as much as we'd love to accept your ideas and contributions, we really don't have the bandwidth. That's what forking is for!
-
-## Forking guidelines
-
-You have our blessing 🪄✨ to fork this application! However, it's very important to be clear to users when you're giving them a fork.
-
-Please be sure to:
-
-- Change all branding in the repository and UI to clearly differentiate from Mu.
-- Change any support links (feedback, email, terms of service, etc) to your own systems.
-- Replace any analytics or error-collection systems with your own so we don't get super confused.
-
-## Security disclosures
-
-If you discover any security issues, please send an email to security@bsky.app. The email is automatically CC'd to the entire team and we'll respond promptly.
-
-## Are you a developer interested in building on atproto?
-
-Mu is an open social network built on the AT Protocol, a flexible technology that will never lock developers out of the ecosystems that they help build. With atproto, third-party integration can be as seamless as first-party through custom feeds, federated services, clients, and more.
+If you discover any security issues related specifically to Mu's deployment or modifications, please contact the Eurosky team. For protocol-level security issues, please follow the [official AT Protocol disclosure process](https://github.com/bluesky-social/atproto).
 
 ## License (MIT)
 
-See [./LICENSE](./LICENSE) for the full license.
-
-Bluesky Social PBC has committed to a software patent non-aggression pledge. For details see [the original announcement](https://bsky.social/about/blog/10-01-2025-patent-pledge).
-
-## P.S.
-
-We ❤️ you and all of the ways you support us. Thank you for making Mu a great place!
+See [./LICENSE](./LICENSE) for the full license. This project is licensed under the MIT License, following the upstream repository's licensing.


### PR DESCRIPTION
This PR updates the project's README to reflect its new focus as 'Mu' (mu.social), a web-app-only social application operated by Eurosky (eurosky.tech). 

Key changes:
- Described Mu as a web-app-only social platform.
- Clarified the project's relationship as a downstream fork of the original Bluesky social application.
- State clearly that Mu is maintained by Eurosky and is not affiliated with Bluesky Social, PBC.
- Updated development resources to reflect the web-only focus.