### PR TITLE
Brooke/thread reader fixes

### DIFF
--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -1,4 +1,4 @@
-import {type ReactNode, useMemo} from 'react'
+import {Fragment, type ReactNode, useMemo} from 'react'
 import {type StyleProp, type TextStyle, View} from 'react-native'
 import {AppBskyRichtextFacet, RichText as RichTextAPI} from '@atproto/api'
 
@@ -36,6 +36,13 @@ export type RichTextProps = TextStyleProp &
     emojiMultiplier?: number
     shouldProxyLinks?: boolean
     /**
+     * Rendered inline after the last text segment, so it flows with the final
+     * line and wraps with the text, e.g. the thread position indicator in the
+     * post thread's linear view. Must be text-compatible (a string or nested
+     * <Text>).
+     */
+    trailing?: ReactNode
+    /**
      * DANGEROUS: Disable facet lexicon validation
      *
      * `detectFacetsWithoutResolution()` generates technically invalid facets,
@@ -64,6 +71,7 @@ export function RichText({
   onTextLayout,
   shouldProxyLinks,
   disableMentionFacetValidation,
+  trailing,
 }: RichTextProps) {
   const richText = useMemo(() => {
     if (value instanceof RichTextAPI) {
@@ -107,6 +115,7 @@ export function RichText({
           // @ts-ignore web only -prf
           dataSet={WORD_WRAP}>
           {parts.map(p => p.node)}
+          {trailing}
         </Text>
       )
     }
@@ -137,6 +146,9 @@ export function RichText({
       } else {
         run.push(part.node)
       }
+    }
+    if (trailing) {
+      run.push(<Fragment key="trailing">{trailing}</Fragment>)
     }
     flushRun()
     // NOTE: posts with a fenced block in a full view render as a <View
@@ -170,6 +182,7 @@ export function RichText({
           // @ts-ignore web only -prf
           dataSet={WORD_WRAP}>
           {text}
+          {trailing}
         </Text>
       )
     }

--- a/src/screens/PostThread/__tests__/reader.test.ts
+++ b/src/screens/PostThread/__tests__/reader.test.ts
@@ -1,6 +1,7 @@
 import {type ThreadItem} from '#/state/queries/usePostThread/types'
 import {
   buildReaderThread,
+  computeSelfThreadPositions,
   type ReaderSegmentItem,
   type ThreadPostItem,
 } from '../reader'
@@ -14,6 +15,8 @@ function post({
   opThread = false,
   moreReplies = 0,
   replyCount = 0,
+  isReply = false,
+  moreParents = false,
 }: {
   rkey: string
   depth: number
@@ -21,6 +24,8 @@ function post({
   opThread?: boolean
   moreReplies?: number
   replyCount?: number
+  isReply?: boolean
+  moreParents?: boolean
 }): ThreadPostItem {
   const uri = `at://${did}/app.bsky.feed.post/${rkey}`
   return {
@@ -32,11 +37,12 @@ function post({
       post: {
         uri,
         author: {did, handle: 'user.test'},
-        record: {},
+        record: isReply ? {reply: {root: {uri: 'at://root'}}} : {},
         replyCount,
       },
       opThread,
       moreReplies,
+      moreParents,
     },
     isBlurred: false,
     moderation: {},
@@ -222,5 +228,171 @@ describe('buildReaderThread', () => {
 
     expect(items[0]).toBe(parent)
     expect(items[1]).toBe(anchor)
+  })
+})
+
+describe('computeSelfThreadPositions', () => {
+  it('numbers the OP chain from the root', () => {
+    const root = post({rkey: 'a', depth: 0})
+    const one = post({rkey: 'b', depth: 1, opThread: true, isReply: true})
+    const two = post({rkey: 'c', depth: 2, opThread: true, isReply: true})
+    const positions = computeSelfThreadPositions([root, composer, one, two])
+
+    expect(positions?.get(root.uri)).toEqual({position: 1, postCount: 3})
+    expect(positions?.get(one.uri)).toEqual({position: 2, postCount: 3})
+    expect(positions?.get(two.uri)).toEqual({position: 3, postCount: 3})
+  })
+
+  it('numbers across parents when anchored mid-chain', () => {
+    const root = post({rkey: 'a', depth: -2})
+    const parent = post({rkey: 'b', depth: -1, opThread: true, isReply: true})
+    const anchor = post({rkey: 'c', depth: 0, opThread: true, isReply: true})
+    const below = post({rkey: 'd', depth: 1, opThread: true, isReply: true})
+    const positions = computeSelfThreadPositions([root, parent, anchor, below])
+
+    expect(positions?.get(root.uri)).toEqual({position: 1, postCount: 4})
+    expect(positions?.get(anchor.uri)).toEqual({position: 3, postCount: 4})
+    expect(positions?.get(below.uri)).toEqual({position: 4, postCount: 4})
+  })
+
+  it('returns undefined when there is no chain', () => {
+    const root = post({rkey: 'a', depth: 0})
+    const reply = post({
+      rkey: 'b',
+      depth: 1,
+      did: 'did:plc:other',
+      isReply: true,
+    })
+
+    expect(computeSelfThreadPositions([root, reply])).toBeUndefined()
+  })
+
+  it('numbers a reply chain by another author', () => {
+    const root = post({rkey: 'a', depth: 0})
+    const replyA = post({
+      rkey: 'b',
+      depth: 1,
+      did: 'did:plc:other',
+      isReply: true,
+    })
+    const replyB = post({
+      rkey: 'c',
+      depth: 2,
+      did: 'did:plc:other',
+      isReply: true,
+    })
+    const positions = computeSelfThreadPositions([root, replyA, replyB])
+
+    expect(positions?.get(root.uri)).toBeUndefined()
+    expect(positions?.get(replyA.uri)).toEqual({position: 1, postCount: 2})
+    expect(positions?.get(replyB.uri)).toEqual({position: 2, postCount: 2})
+  })
+
+  it('finds the continuation among non-adjacent siblings of the anchor', () => {
+    const root = post({rkey: 'a', depth: 0})
+    const other = post({
+      rkey: 'b',
+      depth: 1,
+      did: 'did:plc:other',
+      isReply: true,
+    })
+    const one = post({rkey: 'c', depth: 1, opThread: true, isReply: true})
+    const two = post({rkey: 'd', depth: 2, opThread: true, isReply: true})
+    const positions = computeSelfThreadPositions([root, other, one, two])
+
+    expect(positions?.get(root.uri)).toEqual({position: 1, postCount: 3})
+    expect(positions?.get(one.uri)).toEqual({position: 2, postCount: 3})
+    expect(positions?.get(two.uri)).toEqual({position: 3, postCount: 3})
+    expect(positions?.get(other.uri)).toBeUndefined()
+  })
+
+  it('skips chains whose start has no hydrated parent', () => {
+    const notRoot = post({rkey: 'b', depth: 0, opThread: true, isReply: true})
+    const below = post({rkey: 'c', depth: 1, opThread: true, isReply: true})
+
+    expect(computeSelfThreadPositions([notRoot, below])).toBeUndefined()
+  })
+
+  it('skips chains truncated above, without renumbering their tail', () => {
+    const truncated = post({
+      rkey: 'a',
+      depth: -1,
+      opThread: true,
+      isReply: true,
+      moreParents: true,
+    })
+    const anchor = post({rkey: 'b', depth: 0, opThread: true, isReply: true})
+    const below = post({rkey: 'c', depth: 1, opThread: true, isReply: true})
+
+    expect(
+      computeSelfThreadPositions([truncated, anchor, below]),
+    ).toBeUndefined()
+  })
+
+  it('skips a non-OP chain cut off by the depth cap', () => {
+    const root = post({rkey: 'a', depth: 0})
+    const replyA = post({
+      rkey: 'b',
+      depth: 1,
+      did: 'did:plc:other',
+      isReply: true,
+    })
+    const replyB = post({
+      rkey: 'c',
+      depth: 2,
+      did: 'did:plc:other',
+      isReply: true,
+      moreReplies: 1,
+    })
+    const readMore: ThreadItem = {
+      type: 'readMore',
+      key: `readMore:${replyB.uri}`,
+      depth: 3,
+      href: '/x',
+      moreReplies: 1,
+      skippedIndentIndices: new Set(),
+    }
+    const positions = computeSelfThreadPositions([
+      root,
+      replyA,
+      replyB,
+      readMore,
+    ])
+
+    expect(positions).toBeUndefined()
+  })
+
+  it('numbers the OP chain even with a trailing read more', () => {
+    const root = post({rkey: 'a', depth: 0})
+    const one = post({rkey: 'b', depth: 1, opThread: true, isReply: true})
+    const two = post({rkey: 'c', depth: 2, opThread: true, isReply: true})
+    const readMore: ThreadItem = {
+      type: 'readMore',
+      key: `readMore:${two.uri}`,
+      depth: 3,
+      href: '/x',
+      moreReplies: 2,
+      skippedIndentIndices: new Set(),
+    }
+    const positions = computeSelfThreadPositions([root, one, two, readMore])
+
+    expect(positions?.get(two.uri)).toEqual({position: 3, postCount: 3})
+  })
+
+  it('ends the chain at an interloper and numbers only the prefix', () => {
+    const root = post({rkey: 'a', depth: 0})
+    const one = post({rkey: 'b', depth: 1, opThread: true, isReply: true})
+    const interloper = post({
+      rkey: 'c',
+      depth: 2,
+      did: 'did:plc:other',
+      opThread: true,
+      isReply: true,
+    })
+    const positions = computeSelfThreadPositions([root, one, interloper])
+
+    expect(positions?.get(root.uri)).toEqual({position: 1, postCount: 2})
+    expect(positions?.get(one.uri)).toEqual({position: 2, postCount: 2})
+    expect(positions?.get(interloper.uri)).toBeUndefined()
   })
 })

--- a/src/screens/PostThread/components/ThreadItemAnchor.tsx
+++ b/src/screens/PostThread/components/ThreadItemAnchor.tsx
@@ -29,6 +29,7 @@ import {
   ReaderSeamControls,
 } from '#/screens/PostThread/components/ReaderSeamControls'
 import {ThreadItemAnchorFollowButton} from '#/screens/PostThread/components/ThreadItemAnchorFollowButton'
+import {ThreadPositionChip} from '#/screens/PostThread/components/ThreadPositionChip'
 import {
   LINEAR_AVI_WIDTH,
   OUTER_SPACE,
@@ -39,6 +40,7 @@ import {
 import {
   type ReaderSeam as ReaderSeamData,
   type ThreadPostItem,
+  type ThreadPostPosition,
 } from '#/screens/PostThread/reader'
 import {atoms as a, useTheme} from '#/alf'
 import {DebugFieldDisplay} from '#/components/DebugFieldDisplay'
@@ -68,6 +70,7 @@ export type ThreadItemAnchorReaderSeam = ReaderSeamData & {
 export function ThreadItemAnchor({
   item,
   readerSeam,
+  threadPosition,
   onPostSuccess,
   threadgateRecord,
   postSource,
@@ -78,6 +81,11 @@ export function ThreadItemAnchor({
    * controls and replies into a seam below the post body.
    */
   readerSeam?: ThreadItemAnchorReaderSeam
+  /**
+   * Set in linear view when the anchor is part of a self-thread: renders a
+   * "(x/n)" position chip at the end of the post text.
+   */
+  threadPosition?: ThreadPostPosition
   onPostSuccess?: (data: OnPostSuccessData) => void
   threadgateRecord?: AppBskyFeedThreadgate.Record
   postSource?: PostSource
@@ -97,6 +105,7 @@ export function ThreadItemAnchor({
       item={item}
       isRoot={isRoot}
       readerSeam={readerSeam}
+      threadPosition={threadPosition}
       postShadow={postShadow}
       onPostSuccess={onPostSuccess}
       threadgateRecord={threadgateRecord}
@@ -175,6 +184,7 @@ const ThreadItemAnchorInner = memo(function ThreadItemAnchorInner({
   item,
   isRoot,
   readerSeam,
+  threadPosition,
   postShadow,
   onPostSuccess,
   threadgateRecord,
@@ -183,6 +193,7 @@ const ThreadItemAnchorInner = memo(function ThreadItemAnchorInner({
   item: ThreadPostItem
   isRoot: boolean
   readerSeam?: ThreadItemAnchorReaderSeam
+  threadPosition?: ThreadPostPosition
   postShadow: Shadow<AppBskyFeedDefs.PostView>
   onPostSuccess?: (data: OnPostSuccessData) => void
   threadgateRecord?: AppBskyFeedThreadgate.Record
@@ -379,8 +390,19 @@ const ThreadItemAnchorInner = memo(function ThreadItemAnchorInner({
                         style={[a.flex_1, a.text_lg]}
                         authorHandle={post.author.handle}
                         shouldProxyLinks={true}
+                        trailing={
+                          threadPosition ? (
+                            <ThreadPositionChip
+                              threadPosition={threadPosition}
+                            />
+                          ) : undefined
+                        }
                       />
                     </View>
+                  ) : threadPosition ? (
+                    // Text-less anchors (e.g. image-only) still show their
+                    // position so the numbering reads without gaps.
+                    <ThreadPositionChip threadPosition={threadPosition} />
                   ) : undefined}
                   <TranslatedPost post={post} postTextStyle={[a.text_lg]} />
                   {post.embed && (

--- a/src/screens/PostThread/components/ThreadItemPost.tsx
+++ b/src/screens/PostThread/components/ThreadItemPost.tsx
@@ -23,11 +23,13 @@ import {type OnPostSuccessData} from '#/state/shell/composer'
 import {useMergedThreadgateHiddenReplies} from '#/state/threadgate-hidden-replies'
 import {PostMeta} from '#/view/com/util/PostMeta'
 import {PreviewableUserAvatar} from '#/view/com/util/UserAvatar'
+import {ThreadPositionChip} from '#/screens/PostThread/components/ThreadPositionChip'
 import {
   LINEAR_AVI_WIDTH,
   OUTER_SPACE,
   REPLY_LINE_WIDTH,
 } from '#/screens/PostThread/const'
+import {type ThreadPostPosition} from '#/screens/PostThread/reader'
 import {atoms as a, useTheme} from '#/alf'
 import {DebugFieldDisplay} from '#/components/DebugFieldDisplay'
 import {useInteractionState} from '#/components/hooks/useInteractionState'
@@ -60,6 +62,11 @@ export type ThreadItemPostProps = {
    * Adjusts the hover overlay, e.g. to start at the reader bracket edge.
    */
   hoverStyle?: StyleProp<ViewStyle>
+  /**
+   * Set in linear view when this post is part of a self-thread: renders a
+   * "(x/n)" position chip at the end of the post text.
+   */
+  threadPosition?: ThreadPostPosition
   onPostSuccess?: (data: OnPostSuccessData) => void
   threadgateRecord?: AppBskyFeedThreadgate.Record
 }
@@ -68,6 +75,7 @@ export function ThreadItemPost({
   item,
   overrides,
   hoverStyle,
+  threadPosition,
   onPostSuccess,
   threadgateRecord,
 }: ThreadItemPostProps) {
@@ -84,6 +92,7 @@ export function ThreadItemPost({
       threadgateRecord={threadgateRecord}
       overrides={overrides}
       hoverStyle={hoverStyle}
+      threadPosition={threadPosition}
       onPostSuccess={onPostSuccess}
     />
   )
@@ -193,6 +202,7 @@ const ThreadItemPostInner = memo(function ThreadItemPostInner({
   postShadow,
   overrides,
   hoverStyle,
+  threadPosition,
   onPostSuccess,
   threadgateRecord,
 }: ThreadItemPostProps & {
@@ -334,6 +344,11 @@ const ThreadItemPostInner = memo(function ThreadItemPostInner({
                     numberOfLines={limitLines ? MAX_POST_LINES : undefined}
                     authorHandle={post.author.handle}
                     shouldProxyLinks={true}
+                    trailing={
+                      threadPosition ? (
+                        <ThreadPositionChip threadPosition={threadPosition} />
+                      ) : undefined
+                    }
                   />
                   {limitLines && (
                     <ShowMoreTextButton
@@ -341,6 +356,12 @@ const ThreadItemPostInner = memo(function ThreadItemPostInner({
                       onPress={onPressShowMore}
                     />
                   )}
+                </View>
+              ) : threadPosition ? (
+                // Text-less posts (e.g. image-only) still show their position
+                // so the numbering reads without gaps.
+                <View style={[a.mb_2xs]}>
+                  <ThreadPositionChip threadPosition={threadPosition} />
                 </View>
               ) : undefined}
               <TranslatedPost hideTranslateLink post={post} />

--- a/src/screens/PostThread/components/ThreadPositionChip.tsx
+++ b/src/screens/PostThread/components/ThreadPositionChip.tsx
@@ -1,0 +1,23 @@
+import {type ThreadPostPosition} from '#/screens/PostThread/reader'
+import {atoms as a, useTheme} from '#/alf'
+import {Text} from '#/components/Typography'
+
+/**
+ * Position indicator shown at the end of a post's text when it is part of a
+ * self-thread in linear view, e.g. "(2/12)". Rendered inline via RichText's
+ * `trailing` prop so it flows with the last line of text. Not translated: it
+ * is purely numeric.
+ */
+export function ThreadPositionChip({
+  threadPosition,
+}: {
+  threadPosition: ThreadPostPosition
+}) {
+  const t = useTheme()
+
+  return (
+    <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
+      {` (${threadPosition.position}/${threadPosition.postCount})`}
+    </Text>
+  )
+}

--- a/src/screens/PostThread/index.tsx
+++ b/src/screens/PostThread/index.tsx
@@ -53,7 +53,11 @@ import {
   ThreadItemTreePost,
   ThreadItemTreePostSkeleton,
 } from '#/screens/PostThread/components/ThreadItemTreePost'
-import {buildReaderThread, type ReaderItem} from '#/screens/PostThread/reader'
+import {
+  buildReaderThread,
+  computeSelfThreadPositions,
+  type ReaderItem,
+} from '#/screens/PostThread/reader'
 import {
   atoms as a,
   native,
@@ -463,6 +467,16 @@ export function PostThread({
   const sourceItems = reader?.items ?? thread.data.items
 
   /*
+   * In linear view, self-thread posts - the OP thread and multi-part replies
+   * alike - get "(x/n)" position chips at the end of their text.
+   */
+  const threadPositions = useMemo(() => {
+    return thread.state.view === 'linear'
+      ? computeSelfThreadPositions(thread.data.items)
+      : undefined
+  }, [thread.state.view, thread.data.items])
+
+  /*
    * Show a floating collapse button when the open seam has replies, so the
    * user can close them without scrolling back up.
    */
@@ -564,6 +578,7 @@ export function PostThread({
               overrides={{
                 topBorder: index === 0,
               }}
+              threadPosition={threadPositions?.get(item.uri)}
               onPostSuccess={optimisticOnPostReply}
             />
           )
@@ -600,6 +615,7 @@ export function PostThread({
                       }
                     : undefined
                 }
+                threadPosition={threadPositions?.get(item.uri)}
                 threadgateRecord={thread.data.threadgate?.record ?? undefined}
                 onPostSuccess={optimisticOnPostReply}
                 postSource={anchorPostSource}
@@ -626,6 +642,7 @@ export function PostThread({
                 overrides={{
                   moderation: thread.state.otherItemsVisible && item.depth > 0,
                 }}
+                threadPosition={threadPositions?.get(item.uri)}
                 onPostSuccess={optimisticOnPostReply}
               />
             )
@@ -688,6 +705,7 @@ export function PostThread({
     [
       thread,
       reader,
+      threadPositions,
       toggleSeam,
       optimisticOnPostReply,
       onReplyToAnchor,

--- a/src/screens/PostThread/reader.ts
+++ b/src/screens/PostThread/reader.ts
@@ -164,6 +164,142 @@ export function buildReaderThread(
   return {items: result, anchorSeam, expandedSeam}
 }
 
+export type ThreadPostPosition = {
+  /** 1-based position in the self-thread, where its first post is 1. */
+  position: number
+  /** Number of posts in the self-thread. */
+  postCount: number
+}
+
+/**
+ * Maps each post of a self-thread - a run of consecutive replies by one
+ * author, i.e. the OP thread from the root or a multi-part reply - to its
+ * "(x/n)" position for the linear view's indicator chips.
+ *
+ * Chains are only numbered when the numbers can be trusted:
+ *
+ * - The start must be verifiably the chain's first post: the thread root, or
+ *   a reply whose parent is hydrated and by another author. Same-author
+ *   forks and posts with unhydrated parents are skipped since their true
+ *   position is unknowable.
+ * - The OP chain is fetched exhaustively (see `extendSelfThreadChain`), so it is
+ *   always complete. Other chains are cut off by the fetch depth cap, which
+ *   surfaces as a "read more" after the last post - skip those rather than
+ *   show a wrong total.
+ */
+export function computeSelfThreadPositions(
+  items: ThreadItem[],
+): Map<string, ThreadPostPosition> | undefined {
+  const positions = new Map<string, ThreadPostPosition>()
+  const claimed = new Set<string>()
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]
+    if (item.type !== 'threadPost' || claimed.has(item.uri)) continue
+    if (!isValidChainStart(items, i)) continue
+
+    const {chain, tipIndex} = collectChain(items, i)
+    for (const post of chain) claimed.add(post.uri)
+    if (chain.length < 2) continue
+
+    const tip = chain[chain.length - 1]
+    if (!tip.value.opThread && isCutOffByDepthCap(items, tipIndex)) continue
+
+    for (let k = 0; k < chain.length; k++) {
+      positions.set(chain[k].uri, {
+        position: k + 1,
+        postCount: chain.length,
+      })
+    }
+  }
+
+  return positions.size ? positions : undefined
+}
+
+/**
+ * A chain start is trustworthy when it is the thread root, or a reply whose
+ * parent - the nearest preceding item one level up - is hydrated and by
+ * another author. A hydrated same-author parent means this post is a fork
+ * off a chain that was numbered (or skipped) already.
+ */
+function isValidChainStart(items: ThreadItem[], index: number): boolean {
+  const item = items[index] as ThreadPostItem
+  if (!item.value.post.record.reply) return true
+  const did = item.value.post.author.did
+  for (let j = index - 1; j >= 0; j--) {
+    const prev = items[j]
+    if (prev.type === 'replyComposer') continue
+    if (!('depth' in prev)) return false
+    if (prev.depth < item.depth) {
+      return (
+        prev.depth === item.depth - 1 &&
+        prev.type === 'threadPost' &&
+        prev.value.post.author.did !== did
+      )
+    }
+  }
+  return false
+}
+
+/**
+ * Collects the self-thread starting at `startIndex`: repeatedly finds the
+ * next same-author child. Children are scanned across the parent's whole
+ * subtree, not just the adjacent item, since the anchor's direct replies are
+ * all hydrated and the continuation may sort after other replies.
+ */
+function collectChain(
+  items: ThreadItem[],
+  startIndex: number,
+): {chain: ThreadPostItem[]; tipIndex: number} {
+  const start = items[startIndex] as ThreadPostItem
+  const did = start.value.post.author.did
+  const chain = [start]
+  let tipIndex = startIndex
+
+  let next = findChainChild(items, tipIndex, did)
+  while (next !== -1) {
+    chain.push(items[next] as ThreadPostItem)
+    tipIndex = next
+    next = findChainChild(items, tipIndex, did)
+  }
+  return {chain, tipIndex}
+}
+
+function findChainChild(
+  items: ThreadItem[],
+  parentIndex: number,
+  did: string,
+): number {
+  const parent = items[parentIndex] as ThreadPostItem
+  for (let j = parentIndex + 1; j < items.length; j++) {
+    const item = items[j]
+    if (item.type === 'replyComposer') continue
+    if (!('depth' in item) || item.depth <= parent.depth) break
+    if (
+      item.depth === parent.depth + 1 &&
+      item.type === 'threadPost' &&
+      item.value.post.author.did === did
+    ) {
+      return j
+    }
+  }
+  return -1
+}
+
+/**
+ * A "read more" immediately after a chain's last post means that post sits
+ * at the fetch depth cap with nothing of its subtree hydrated - the chain
+ * may well continue behind it.
+ */
+function isCutOffByDepthCap(items: ThreadItem[], tipIndex: number): boolean {
+  for (let j = tipIndex + 1; j < items.length; j++) {
+    const item = items[j]
+    if (item.type === 'replyComposer') continue
+    return item.type === 'readMore'
+  }
+  return false
+}
+
 function createSeam(
   post: ThreadPostItem,
   {

--- a/src/state/queries/usePostThread/__tests__/selfThreadChain.test.ts
+++ b/src/state/queries/usePostThread/__tests__/selfThreadChain.test.ts
@@ -1,0 +1,202 @@
+import {
+  AppBskyUnspeccedDefs,
+  type AppBskyUnspeccedGetPostThreadV2,
+} from '@atproto/api'
+
+import {extendSelfThreadChain} from '../selfThreadChain'
+
+type RawThreadItem = AppBskyUnspeccedGetPostThreadV2.ThreadItem
+
+const OP_DID = 'did:plc:op'
+
+function post({
+  rkey,
+  depth,
+  did = OP_DID,
+  opThread = true,
+  moreReplies = 0,
+  replyCount = 0,
+}: {
+  rkey: string
+  depth: number
+  did?: string
+  opThread?: boolean
+  moreReplies?: number
+  replyCount?: number
+}): RawThreadItem {
+  const uri = `at://${did}/app.bsky.feed.post/${rkey}`
+  return {
+    uri,
+    depth,
+    value: {
+      $type: 'app.bsky.unspecced.defs#threadItemPost',
+      post: {
+        uri,
+        author: {did, handle: 'user.test'},
+        record: {},
+        replyCount,
+      },
+      moreParents: false,
+      moreReplies,
+      opThread,
+      hiddenByThreadgate: false,
+      mutedByViewer: false,
+    },
+  } as unknown as RawThreadItem
+}
+
+const rkeys = (thread: RawThreadItem[]) =>
+  thread.map(item => item.uri.split('/').pop())
+
+const depths = (thread: RawThreadItem[]) => thread.map(item => item.depth)
+
+describe('extendSelfThreadChain', () => {
+  it('does not fetch when the chain tip has a hydrated child', async () => {
+    const fetchBelow = jest.fn()
+    // the tip has replies, but one is hydrated below it, so the tip did not
+    // sit at the response's depth cap and the chain ended for real
+    const thread = [
+      post({rkey: 'a', depth: 0, replyCount: 1}),
+      post({rkey: 'b', depth: 1, replyCount: 1}),
+      post({rkey: 'c', depth: 2, replyCount: 1, moreReplies: 0}),
+      post({rkey: 'x', depth: 3, did: 'did:plc:other'}),
+    ]
+    const result = await extendSelfThreadChain({thread, fetchBelow})
+
+    expect(fetchBelow).not.toHaveBeenCalled()
+    expect(result).toBe(thread)
+  })
+
+  it('extends a chain truncated at the depth cap', async () => {
+    const thread = [
+      post({rkey: 'a', depth: 0, replyCount: 1}),
+      post({rkey: 'b', depth: 1, replyCount: 1}),
+      post({rkey: 'c', depth: 2, replyCount: 1}),
+      post({rkey: 'd', depth: 3, replyCount: 2, moreReplies: 2}),
+    ]
+    const fetchBelow = jest
+      .fn()
+      .mockResolvedValue([
+        post({rkey: 'd', depth: 0, replyCount: 2, moreReplies: 1}),
+        post({rkey: 'e', depth: 1, replyCount: 1}),
+        post({rkey: 'f', depth: 2}),
+      ])
+    const result = await extendSelfThreadChain({thread, fetchBelow})
+
+    expect(fetchBelow).toHaveBeenCalledTimes(1)
+    expect(fetchBelow).toHaveBeenCalledWith(thread[3].uri)
+    expect(rkeys(result)).toEqual(['a', 'b', 'c', 'd', 'e', 'f'])
+    // continuation depths are made absolute
+    expect(depths(result)).toEqual([0, 1, 2, 3, 4, 5])
+    // the old tip's continuation is now hydrated, so moreReplies drops by one
+    const tipValue = result[3].value
+    if (!AppBskyUnspeccedDefs.isThreadItemPost(tipValue)) {
+      throw new Error('expected tip to be a post')
+    }
+    expect(tipValue.moreReplies).toBe(1)
+  })
+
+  it('keeps fetching until the chain ends naturally', async () => {
+    const thread = [
+      post({rkey: 'a', depth: 0, replyCount: 1}),
+      post({rkey: 'b', depth: 1, replyCount: 1}),
+      post({rkey: 'c', depth: 2, replyCount: 1}),
+      post({rkey: 'd', depth: 3, replyCount: 1, moreReplies: 1}),
+    ]
+    const pages: RawThreadItem[][] = [
+      [
+        post({rkey: 'd', depth: 0, replyCount: 1}),
+        post({rkey: 'e', depth: 1, replyCount: 1}),
+        post({rkey: 'f', depth: 2, replyCount: 1}),
+        post({rkey: 'g', depth: 3, replyCount: 1, moreReplies: 1}),
+      ],
+      [post({rkey: 'g', depth: 0, replyCount: 1}), post({rkey: 'h', depth: 1})],
+    ]
+    const fetchBelow = jest.fn(() => Promise.resolve(pages.shift()!))
+    const result = await extendSelfThreadChain({thread, fetchBelow})
+
+    expect(fetchBelow).toHaveBeenCalledTimes(2)
+    expect(rkeys(result)).toEqual(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'])
+    expect(depths(result)).toEqual([0, 1, 2, 3, 4, 5, 6, 7])
+  })
+
+  it('stops at maxFetches even if the chain continues', async () => {
+    const thread = [
+      post({rkey: 'a', depth: 0, replyCount: 1}),
+      post({rkey: 'b0', depth: 1, replyCount: 1}),
+      post({rkey: 'b1', depth: 2, replyCount: 1}),
+      post({rkey: 'b2', depth: 3, replyCount: 1, moreReplies: 1}),
+    ]
+    let n = 2
+    const fetchBelow = jest.fn((anchorUri: string) => {
+      const anchorRkey = anchorUri.split('/').pop()
+      return Promise.resolve([
+        post({rkey: anchorRkey!, depth: 0, replyCount: 1}),
+        post({rkey: `c${n}`, depth: 1, replyCount: 1}),
+        post({rkey: `c${n + 1}`, depth: 2, replyCount: 1}),
+        post({rkey: `c${n++}x`, depth: 3, replyCount: 1, moreReplies: 1}),
+      ])
+    })
+    const result = await extendSelfThreadChain({
+      thread,
+      maxFetches: 2,
+      fetchBelow,
+    })
+
+    expect(fetchBelow).toHaveBeenCalledTimes(2)
+    expect(result.length).toBe(4 + 2 * 3)
+  })
+
+  it('stops when the continuation has no OP chain', async () => {
+    const thread = [
+      post({rkey: 'a', depth: 0, replyCount: 1}),
+      post({rkey: 'b', depth: 1, replyCount: 1}),
+      post({rkey: 'c', depth: 2, replyCount: 1}),
+      post({rkey: 'd', depth: 3, replyCount: 1, moreReplies: 1}),
+    ]
+    const fetchBelow = jest
+      .fn()
+      .mockResolvedValue([
+        post({rkey: 'd', depth: 0, replyCount: 1}),
+        post({rkey: 'x', depth: 1, did: 'did:plc:other'}),
+      ])
+    const result = await extendSelfThreadChain({thread, fetchBelow})
+
+    expect(fetchBelow).toHaveBeenCalledTimes(1)
+    expect(rkeys(result)).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  it('skips the fetch when the tip has no replies', async () => {
+    const fetchBelow = jest.fn()
+    const thread = [
+      post({rkey: 'a', depth: 0, replyCount: 1}),
+      post({rkey: 'b', depth: 1, replyCount: 1}),
+      post({rkey: 'c', depth: 2, replyCount: 1}),
+      post({rkey: 'd', depth: 3, replyCount: 0, moreReplies: 0}),
+    ]
+    const result = await extendSelfThreadChain({thread, fetchBelow})
+
+    expect(fetchBelow).not.toHaveBeenCalled()
+    expect(rkeys(result)).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  it('splices the continuation before trailing sibling branches', async () => {
+    const thread = [
+      post({rkey: 'a', depth: 0, replyCount: 2}),
+      post({rkey: 'b', depth: 1, replyCount: 1}),
+      post({rkey: 'c', depth: 2, replyCount: 1}),
+      post({rkey: 'd', depth: 3, replyCount: 1, moreReplies: 1}),
+      post({rkey: 'z', depth: 1, did: 'did:plc:other', opThread: false}),
+    ]
+    const fetchBelow = jest
+      .fn()
+      .mockResolvedValue([
+        post({rkey: 'd', depth: 0, replyCount: 1}),
+        post({rkey: 'e', depth: 1}),
+      ])
+    const result = await extendSelfThreadChain({thread, fetchBelow})
+
+    expect(rkeys(result)).toEqual(['a', 'b', 'c', 'd', 'e', 'z'])
+    expect(depths(result)).toEqual([0, 1, 2, 3, 4, 1])
+  })
+})

--- a/src/state/queries/usePostThread/const.ts
+++ b/src/state/queries/usePostThread/const.ts
@@ -35,3 +35,12 @@ export const TREE_VIEW_BELOW_DESKTOP = 6
  * seam transform relies on that, see `createSeam` in PostThread/reader.ts.
  */
 export const READER_VIEW_BELOW = 20
+
+/**
+ * Upper bound on continuation fetches when extending an OP self-thread past
+ * the server's depth cap, i.e. at most `(SELF_THREAD_CHAIN_MAX_FETCHES + 1) *
+ * <server depth cap>` chain posts load per view. The appview currently
+ * serves at most 10 levels per request regardless of the requested `below`.
+ * See `extendSelfThreadChain`.
+ */
+export const SELF_THREAD_CHAIN_MAX_FETCHES = 10

--- a/src/state/queries/usePostThread/index.ts
+++ b/src/state/queries/usePostThread/index.ts
@@ -19,6 +19,7 @@ import {
   createCacheMutator,
   getThreadPlaceholder,
 } from '#/state/queries/usePostThread/queryCache'
+import {extendSelfThreadChain} from '#/state/queries/usePostThread/selfThreadChain'
 import {
   buildThread,
   sortAndAnnotateThreadItems,
@@ -96,6 +97,32 @@ export function usePostThread({
         sort: sort,
       })
 
+      let threadData = data.thread || []
+
+      /*
+       * An OP self-thread longer than the depth the server serves arrives
+       * truncated. Reader view reads the whole chain and linear view numbers
+       * it with "(x/n)" chips, so extend it with follow-up fetches anchored
+       * progressively deeper.
+       */
+      if (apiView === 'linear') {
+        threadData = await extendSelfThreadChain({
+          thread: threadData,
+          fetchBelow: async anchorUri => {
+            const {data: more} = await agent.app.bsky.unspecced.getPostThreadV2(
+              {
+                anchor: anchorUri,
+                above: false,
+                branchingFactor: LINEAR_VIEW_BF,
+                below,
+                sort: sort,
+              },
+            )
+            return more.thread || []
+          },
+        })
+      }
+
       /*
        * Initialize `ctx.meta` to track if we know we have additional replies
        * we could fetch once we hit the end.
@@ -112,7 +139,7 @@ export function usePostThread({
       }
 
       const result = {
-        thread: data.thread || [],
+        thread: threadData,
         threadgate: data.threadgate,
         hasOtherReplies: !!ctx.meta.hasOtherReplies,
       }

--- a/src/state/queries/usePostThread/selfThreadChain.ts
+++ b/src/state/queries/usePostThread/selfThreadChain.ts
@@ -1,0 +1,137 @@
+import {
+  AppBskyUnspeccedDefs,
+  type AppBskyUnspeccedGetPostThreadV2,
+} from '@atproto/api'
+
+import {SELF_THREAD_CHAIN_MAX_FETCHES} from '#/state/queries/usePostThread/const'
+
+type RawThreadItem = AppBskyUnspeccedGetPostThreadV2.ThreadItem
+
+function isOpChainPost(
+  item: RawThreadItem,
+  did: string,
+): item is RawThreadItem & {
+  value: AppBskyUnspeccedDefs.ThreadItemPost
+} {
+  return (
+    AppBskyUnspeccedDefs.isThreadItemPost(item.value) &&
+    item.value.opThread &&
+    item.value.post.author.did === did
+  )
+}
+
+/**
+ * Locates the OP self-thread chain hanging off the response anchor: the first
+ * depth-1 `opThread` post by `did`, plus the contiguous one-level-deeper run
+ * below it. Mirrors the chain walk in PostThread/reader.ts, but over raw
+ * response items. Chain items are contiguous indices `start..end` because
+ * branches are served depth-first.
+ */
+function findChain(
+  thread: RawThreadItem[],
+  did: string,
+): {start: number; end: number} | undefined {
+  const start = thread.findIndex(
+    item => item.depth === 1 && isOpChainPost(item, did),
+  )
+  if (start === -1) return undefined
+  let end = start
+  while (end + 1 < thread.length) {
+    const next = thread[end + 1]
+    if (next.depth === thread[end].depth + 1 && isOpChainPost(next, did)) {
+      end++
+    } else {
+      break
+    }
+  }
+  return {start, end}
+}
+
+/**
+ * The endpoint caps the depth served per request, and linear-shaped fetches
+ * descend the OP self-thread one level per post, so a long enough
+ * self-thread arrives truncated. When the chain ends at the depth cap,
+ * refetch anchored at the deepest post and splice the continuation into the
+ * response, repeating until the chain ends naturally or `maxFetches` is
+ * reached.
+ *
+ * The cap is whatever the server actually enforces, which can be lower than
+ * the requested `below` (the appview currently clamps to 10 despite the
+ * lexicon allowing 20), so truncation is detected structurally: a chain tip
+ * with no hydrated child sat at the cap, while a tip followed by any
+ * hydrated child - another author's reply, a tombstone - ended for real.
+ *
+ * The splice keeps the response linear-shaped (depth-first, depths made
+ * absolute), so downstream traversal and the reader transform are unaware of
+ * the stitching. The old tip's `moreReplies` is decremented since its chain
+ * continuation is now present in the response - reader seam counts rely on
+ * that value being exact, see `createSeam` in PostThread/reader.ts.
+ */
+export async function extendSelfThreadChain({
+  thread,
+  maxFetches = SELF_THREAD_CHAIN_MAX_FETCHES,
+  fetchBelow,
+}: {
+  thread: RawThreadItem[]
+  maxFetches?: number
+  /** Fetches more levels anchored at the given post, without parents. */
+  fetchBelow: (anchorUri: string) => Promise<RawThreadItem[]>
+}): Promise<RawThreadItem[]> {
+  const anchor = thread.find(item => item.depth === 0)
+  if (!anchor || !AppBskyUnspeccedDefs.isThreadItemPost(anchor.value)) {
+    return thread
+  }
+  const did = anchor.value.post.author.did
+
+  const chain = findChain(thread, did)
+  if (!chain) return thread
+
+  let result = thread
+  let tipIndex = chain.end
+  let tipMaybeTruncated = !hasHydratedChild(thread, chain.end)
+
+  for (let i = 0; i < maxFetches && tipMaybeTruncated; i++) {
+    const tip = result[tipIndex]
+    const tipValue = tip.value
+    if (!AppBskyUnspeccedDefs.isThreadItemPost(tipValue)) break
+    if (tipValue.moreReplies === 0 && (tipValue.post.replyCount ?? 0) === 0) {
+      // the tip has no replies at all, so there is nothing to extend
+      break
+    }
+
+    const continuation = await fetchBelow(tip.uri)
+    const contChain = findChain(continuation, did)
+    if (!contChain) break
+
+    const contItems = continuation
+      .slice(contChain.start, contChain.end + 1)
+      .map(item => ({...item, depth: item.depth + tip.depth}))
+    const settledTip: RawThreadItem = {
+      ...tip,
+      value: {
+        ...tipValue,
+        moreReplies: Math.max(0, tipValue.moreReplies - 1),
+      },
+    }
+    result = [
+      ...result.slice(0, tipIndex),
+      settledTip,
+      ...contItems,
+      ...result.slice(tipIndex + 1),
+    ]
+    tipIndex += contItems.length
+    tipMaybeTruncated = !hasHydratedChild(continuation, contChain.end)
+  }
+
+  return result
+}
+
+/**
+ * Whether the post at `index` has any hydrated child - an item directly
+ * after it one level deeper. In a depth-first response a post's subtree
+ * follows it immediately, so an absent or shallower next item means nothing
+ * below this post was served.
+ */
+function hasHydratedChild(thread: RawThreadItem[], index: number): boolean {
+  return thread[index + 1]?.depth === thread[index].depth + 1
+}


### PR DESCRIPTION
Fixes reader mode not showing complete threads when they are very long. 

Adds (x/n) count to end of threads. 