### PR TITLE
fix: show onboarding after OAuth signup without a reload

### DIFF
--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -45,7 +45,10 @@ import {Provider as ShellStateProvider} from '#/state/shell'
 import {Provider as ComposerProvider} from '#/state/shell/composer'
 import {Provider as LandingProvider} from '#/state/shell/landing'
 import {Provider as LoggedOutViewProvider} from '#/state/shell/logged-out'
-import {Provider as OnboardingProvider} from '#/state/shell/onboarding'
+import {
+  Provider as OnboardingProvider,
+  useOnboardingDispatch,
+} from '#/state/shell/onboarding'
 import {Provider as ProgressGuideProvider} from '#/state/shell/progress-guide'
 import {Provider as SelectedFeedProvider} from '#/state/shell/selected-feed'
 import {Provider as HiddenRepliesProvider} from '#/state/threadgate-hidden-replies'
@@ -97,6 +100,7 @@ function InnerApp() {
   const [isReady, setIsReady] = useState(false)
   const {currentAccount} = useSession()
   const {resumeSession, login} = useSessionApi()
+  const onboardingDispatch = useOnboardingDispatch()
   const theme = useColorModeTheme()
   const themesOverride = useThemesOverride() // Eurosky: per-user accent
   const {t: l} = useLingui()
@@ -108,7 +112,11 @@ function InnerApp() {
       try {
         // Finish an OAuth sign-in if we returned to the site root with
         // callback params; otherwise resume the stored session as usual.
-        if (await tryFinishWebOAuthSignIn(login)) {
+        if (
+          await tryFinishWebOAuthSignIn(login, () =>
+            onboardingDispatch({type: 'start'}),
+          )
+        ) {
           return
         }
         if (account) {
@@ -124,7 +132,7 @@ function InnerApp() {
     }
     const account = readLastActiveAccount()
     void onLaunch(account)
-  }, [resumeSession, login])
+  }, [resumeSession, login, onboardingDispatch])
 
   useEffect(() => {
     return listenSessionDropped(() => {

--- a/src/state/session/oauth-web-callback.ts
+++ b/src/state/session/oauth-web-callback.ts
@@ -6,7 +6,6 @@
  * provider returns the user to `/` with params, and we finish sign-in at
  * app startup here.
  */
-import * as persisted from '#/state/persisted'
 import {type SessionApiContext} from '#/state/session/types'
 import {
   getWebOAuthClient,
@@ -46,17 +45,12 @@ function hasOAuthCallbackParams(): boolean {
  */
 export async function tryFinishWebOAuthSignIn(
   login: SessionApiContext['login'],
+  startOnboarding: () => void,
 ): Promise<boolean> {
   if (!hasOAuthCallbackParams()) return false
   const client = getWebOAuthClient()
   const result = await client.init()
   if (result?.session) {
-    // A fresh signup (prompt=create) is created on the external PDS page, which
-    // never runs our in-app signup wizard - so start onboarding here, the same
-    // way that wizard does. Plain sign-ins carry no state and are untouched.
-    if (result.state === OAUTH_SIGNUP_STATE) {
-      await persisted.write('onboarding', {step: 'Welcome'})
-    }
     // For a handle step-up the DID is unchanged, so login() replaces the
     // existing session in place with the upgraded (identity:handle) tokens.
     await login(
@@ -68,6 +62,20 @@ export async function tryFinishWebOAuthSignIn(
       },
       'LoginForm',
     )
+    // A fresh signup (prompt=create) is created on the external PDS page, which
+    // never runs our in-app signup wizard - so start onboarding here, the same
+    // way that wizard does. Plain sign-ins carry no state and are untouched.
+    //
+    // We drive the in-memory onboarding reducer (startOnboarding) rather than
+    // only writing persisted state. OnboardingProvider is mounted above the
+    // session, so login() never remounts it, and on web persisted.write() does
+    // not fire onUpdate listeners in the same tab (its cross-tab
+    // BroadcastChannel never echoes back to the sender). A bare write would
+    // leave the onboarding context stale and the wizard would not appear until
+    // a manual reload. The reducer's 'start' action persists the step itself.
+    if (result.state === OAUTH_SIGNUP_STATE) {
+      startOnboarding()
+    }
     if (result.state === OAUTH_HANDLE_STEPUP_STATE) {
       // The redirect lands at the site root; rewrite the path before the
       // navigator reads it so web linking resolves to account settings, where


### PR DESCRIPTION
A fresh account created via the external PDS OAuth flow never runs the in-app signup wizard, so we start onboarding on the web OAuth callback. It previously did this with persisted.write('onboarding', ...), but on web that never activated onboarding in the current tab: OnboardingProvider is mounted above the session and is never remounted by login(), and persisted.write() does not fire local onUpdate listeners (its cross-tab BroadcastChannel never echoes back to the sender). The wizard only appeared after a manual reload, which re-read the persisted step.

Drive the in-memory onboarding reducer instead (dispatch 'start', which also persists the step) by threading an onboarding dispatch from InnerApp into tryFinishWebOAuthSignIn.