### PR TITLE
Bot mitigation: robots.txt + Bunny edge rules & per-IP limits for mu.social

### DIFF
--- a/.github/workflows/deploy-web-bunny.yml
+++ b/.github/workflows/deploy-web-bunny.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Build web
         run: bash ./scripts/bunny_build.sh
         env:
+          # Prod: ship the crawl-scoped robots.txt (web/robots.txt). Explicit
+          # for symmetry with staging/dev; "prod" is also the build default.
+          ROBOTS_MODE: prod
           # Geolocation decides which regional moderation labelers are required;
           # without it the app fail-closes and subscribes ALL of them. Served
           # first-party from Bunny (see services/geolocation/), not ip.bsky.app.
@@ -69,5 +72,13 @@ jobs:
         env:
           BUNNY_STORAGE_ZONE: ${{ secrets.BUNNY_STORAGE_ZONE }}
           BUNNY_STORAGE_PASSWORD: ${{ secrets.BUNNY_STORAGE_PASSWORD }}
+          BUNNY_API_KEY: ${{ secrets.BUNNY_API_KEY }}
+          BUNNY_PULLZONE_ID: ${{ secrets.BUNNY_PULLZONE_ID }}
+      # Bot-mitigation config (network limits + cache/block edge rules) applied
+      # as infrastructure-as-code. Idempotent - matches existing rules by
+      # description and updates in place, so it is safe to run every deploy.
+      - name: Apply Bunny edge config (limits + rules)
+        run: bash ./scripts/bunny_edge_setup.sh
+        env:
           BUNNY_API_KEY: ${{ secrets.BUNNY_API_KEY }}
           BUNNY_PULLZONE_ID: ${{ secrets.BUNNY_PULLZONE_ID }}

--- a/.github/workflows/deploy-web-dev-bunny.yml
+++ b/.github/workflows/deploy-web-dev-bunny.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Build web
         run: bash ./scripts/bunny_build.sh
         env:
+          # Non-prod: ship the disallow-all robots.txt so dev stays out of
+          # search (paired with the zone's noindex X-Robots-Tag edge rule).
+          ROBOTS_MODE: disallow-all
           # Dev is its own atproto OAuth client: client_id derives from this
           # base URL (gen-oauth-metadata.js emits the metadata into the build,
           # so dev self-publishes it at /oauth-client-metadata.json).
@@ -97,5 +100,14 @@ jobs:
         env:
           BUNNY_STORAGE_ZONE: ${{ secrets.DEV_BUNNY_STORAGE_ZONE }}
           BUNNY_STORAGE_PASSWORD: ${{ secrets.DEV_BUNNY_STORAGE_PASSWORD }}
+          BUNNY_API_KEY: ${{ secrets.BUNNY_API_KEY }}
+          BUNNY_PULLZONE_ID: ${{ secrets.DEV_BUNNY_PULLZONE_ID }}
+      # Bot-mitigation config (network limits + cache/block edge rules), applied
+      # to the DEV pull zone. Idempotent - matches existing rules by description
+      # and updates in place, so it is safe to run every deploy. The noindex
+      # X-Robots-Tag edge rule on this zone is untouched (additive).
+      - name: Apply Bunny edge config (limits + rules)
+        run: bash ./scripts/bunny_edge_setup.sh
+        env:
           BUNNY_API_KEY: ${{ secrets.BUNNY_API_KEY }}
           BUNNY_PULLZONE_ID: ${{ secrets.DEV_BUNNY_PULLZONE_ID }}

--- a/.github/workflows/deploy-web-staging-bunny.yml
+++ b/.github/workflows/deploy-web-staging-bunny.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Build web
         run: bash ./scripts/bunny_build.sh
         env:
+          # Non-prod: ship the disallow-all robots.txt so staging stays out of
+          # search (paired with the zone's noindex X-Robots-Tag edge rule).
+          ROBOTS_MODE: disallow-all
           # Staging is its own atproto OAuth client: client_id derives from this
           # base URL (gen-oauth-metadata.js emits the metadata into the build,
           # so staging self-publishes it at /oauth-client-metadata.json).
@@ -88,5 +91,14 @@ jobs:
         env:
           BUNNY_STORAGE_ZONE: ${{ secrets.STAGING_BUNNY_STORAGE_ZONE }}
           BUNNY_STORAGE_PASSWORD: ${{ secrets.STAGING_BUNNY_STORAGE_PASSWORD }}
+          BUNNY_API_KEY: ${{ secrets.BUNNY_API_KEY }}
+          BUNNY_PULLZONE_ID: ${{ secrets.STAGING_BUNNY_PULLZONE_ID }}
+      # Bot-mitigation config (network limits + cache/block edge rules), applied
+      # to the STAGING pull zone. Idempotent - matches existing rules by
+      # description and updates in place, so it is safe to run every deploy. The
+      # noindex X-Robots-Tag edge rule on this zone is untouched (additive).
+      - name: Apply Bunny edge config (limits + rules)
+        run: bash ./scripts/bunny_edge_setup.sh
+        env:
           BUNNY_API_KEY: ${{ secrets.BUNNY_API_KEY }}
           BUNNY_PULLZONE_ID: ${{ secrets.STAGING_BUNNY_PULLZONE_ID }}

--- a/scripts/bunny_build.sh
+++ b/scripts/bunny_build.sh
@@ -58,4 +58,11 @@ sed -i'' -E 's#"static/#"/static/#g' web-build/index.html
 # Clean up the BSD sed backup file if any
 rm -f web-build/index.html-E
 
+# robots.txt: disallow the high-cardinality, JS-only routes (profiles, posts,
+# hashtags, search, ...) so crawlers stop treating every federated permalink
+# as a unique page and re-downloading the JS bundles per URL. Expo does not
+# reliably copy arbitrary files out of web/, so copy it explicitly. See
+# web/robots.txt for the rationale.
+cp web/robots.txt web-build/robots.txt
+
 echo "Build complete. Output: web-build/"

--- a/scripts/bunny_build.sh
+++ b/scripts/bunny_build.sh
@@ -58,11 +58,20 @@ sed -i'' -E 's#"static/#"/static/#g' web-build/index.html
 # Clean up the BSD sed backup file if any
 rm -f web-build/index.html-E
 
-# robots.txt: disallow the high-cardinality, JS-only routes (profiles, posts,
-# hashtags, search, ...) so crawlers stop treating every federated permalink
-# as a unique page and re-downloading the JS bundles per URL. Expo does not
-# reliably copy arbitrary files out of web/, so copy it explicitly. See
-# web/robots.txt for the rationale.
-cp web/robots.txt web-build/robots.txt
+# robots.txt: chosen per environment. Expo does not reliably copy arbitrary
+# files out of web/, so copy it explicitly.
+#   - prod (default): web/robots.txt disallows the high-cardinality, JS-only
+#     routes (profiles, posts, hashtags, search, ...) so crawlers stop treating
+#     every federated permalink as a unique page and re-downloading the JS
+#     bundles per URL. See web/robots.txt for the rationale.
+#   - non-prod (ROBOTS_MODE=disallow-all): web/robots.disallow.txt blocks all
+#     crawling, so staging/dev stay out of search entirely.
+# Prod-style is the default so a forgotten flag fails safe (a crawlable-but-
+# noindexed non-prod), never an accidentally deindexed prod.
+if [[ "${ROBOTS_MODE:-prod}" == "disallow-all" ]]; then
+  cp web/robots.disallow.txt web-build/robots.txt
+else
+  cp web/robots.txt web-build/robots.txt
+fi
 
 echo "Build complete. Output: web-build/"

--- a/scripts/bunny_edge_setup.sh
+++ b/scripts/bunny_edge_setup.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Eurosky fork: configure the Bunny.net pull zone (5945167) for the mu.social
+# bot-crawl incident. Two parts:
+#
+#   A. Global network limits (per client IP, whole zone) - the real bandwidth
+#      guard. A throttled/blocked request costs a few hundred bytes instead of
+#      a ~2 MB JS bundle, so this is what caps anything ignoring robots.txt.
+#
+#   B. Three edge rules - caching hygiene (1, 2) plus a cheap block for naive
+#      library scrapers (3). Caching does NOT lower the bill (Bunny bills
+#      edge->client delivery on every hit); it only saves origin reads and
+#      improves hit ratio/latency.
+#
+# We do NOT block Googlebot (66.249.64.0/19) here - robots.txt already stops it
+# crawling the high-cardinality paths, and hard-blocking it can hurt ranking.
+#
+# Reads from the environment (or ./.env):
+#   BUNNY_API_KEY       account-level API key (Account Settings -> API)
+#   BUNNY_PULLZONE_ID   numeric pull zone id, required (5945167 = prod, or the
+#                       staging/dev zone id). No default - see the check below.
+#
+# Usage (from the repo root):
+#   ./scripts/bunny_edge_setup.sh
+#
+# Idempotent: the pull-zone update overwrites those fields, and each edge rule
+# is matched to an existing one by its Description (see merge_guid) so re-runs
+# update in place instead of creating duplicates. Safe to run repeatedly.
+#
+# API refs:
+#   Update pull zone:  POST https://api.bunny.net/pullzone/{id}
+#   Add/update rule:   POST https://api.bunny.net/pullzone/{id}/edgerules/addOrUpdate
+#
+# Field mappings verified against the official BunnyWay Terraform provider
+# (internal/api/pullzone.go), 2026-07 - the dashboard "Network limits" inputs:
+#   Requests limits (req/s per IP) -> RequestLimit
+#   Burst requests                 -> BurstSize
+#   Maximum connections per IP     -> ConnectionLimitPerIPCount
+#   Download speed limits (kB/s)   -> LimitRatePerSecond   (NOT requests!)
+#   Limit after (kB)               -> LimitRateAfter
+#   Monthly bandwidth limit (bytes)-> MonthlyBandwidthLimit
+#
+# Edge-rule enums (docs.bunny.net):
+#   ActionType:  OverrideCacheTime=3  BlockRequest=4  OverrideBrowserCacheTime=16
+#   TriggerType: Url=0  RequestHeader=1
+#   MatchType:   MatchAny=0
+# ActionParameter1 carries the action's value (seconds for the cache overrides).
+set -euo pipefail
+
+if [[ -z "${BUNNY_API_KEY:-}" || -z "${BUNNY_PULLZONE_ID:-}" ]]; then
+  if [[ -f .env ]]; then set -a; . ./.env; set +a; fi
+fi
+: "${BUNNY_API_KEY:?set BUNNY_API_KEY (account-level API key)}"
+# Required, no default: this script runs against prod (5945167), staging, and
+# dev zones. A silent prod fallback here would let a staging/dev deploy with a
+# missing/empty pull-zone secret reconfigure PRODUCTION. Fail loudly instead.
+: "${BUNNY_PULLZONE_ID:?set BUNNY_PULLZONE_ID (numeric pull zone id, e.g. 5945167 for prod)}"
+
+API="https://api.bunny.net/pullzone/${BUNNY_PULLZONE_ID}"
+HDR_KEY="AccessKey: ${BUNNY_API_KEY}"
+HDR_JSON="Content-Type: application/json"
+
+say() { printf '\n== %s\n' "$*"; }
+
+# Snapshot of existing edge rules, fetched once so re-runs are idempotent.
+# addOrUpdate CREATES when no Guid is given and UPDATES when a Guid is given -
+# but a Guid that does not exist yet 404s ("edge_rule_not_found"). So we never
+# hardcode a Guid: instead we match an existing rule by its Description and
+# reuse its Guid, otherwise create fresh.
+PZ_FILE="$(mktemp)"
+trap 'rm -f "$PZ_FILE"' EXIT
+curl -sS "$API" -H "$HDR_KEY" > "$PZ_FILE"
+
+# Inject the Guid of the already-existing rule with the same Description (if
+# any) into the given body, so a re-run updates in place instead of adding a
+# duplicate. Prints the (possibly augmented) body.
+merge_guid() {
+  BODY="$1" PZ="$PZ_FILE" python3 -c '
+import os, json
+body = json.loads(os.environ["BODY"])
+try:
+    pz = json.load(open(os.environ["PZ"]))
+    for r in pz.get("EdgeRules", []):
+        if r.get("Description") == body.get("Description"):
+            body["Guid"] = r["Guid"]
+            break
+except Exception:
+    pass
+print(json.dumps(body))'
+}
+
+# POST an edge rule body (Guid resolved via merge_guid); fail loudly on non-2xx.
+add_rule() {
+  local desc="$1" body code
+  body="$(merge_guid "$2")"
+  code=$(curl -sS -o /tmp/bunny_rule.out -w '%{http_code}' -X POST \
+    "${API}/edgerules/addOrUpdate" -H "$HDR_KEY" -H "$HDR_JSON" -d "$body")
+  if [[ "$code" == 2* ]]; then
+    echo "  ok   ${desc}"
+  else
+    echo "  FAIL ${desc} (HTTP $code)"; cat /tmp/bunny_rule.out; echo; return 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# A. Global network limits (per client IP)
+# ---------------------------------------------------------------------------
+# RequestLimit is the sustained per-IP ceiling; BurstSize absorbs the ~30-50
+# request fan-out of a real cold page load so genuine users are not 429'd.
+# LimitRatePerSecond / LimitRateAfter are the download-SPEED throttle (kB/s) -
+# left at 0 (unlimited) because slowing a download does not reduce bytes billed
+# and would hurt real users. MonthlyBandwidthLimit=0 (no hard kill-switch).
+say "Updating global network limits (per-IP throttling)"
+curl -sS -o /dev/null -w 'HTTP %{http_code}\n' -X POST "$API" \
+  -H "$HDR_KEY" -H "$HDR_JSON" -d '{
+    "RequestLimit": 4,
+    "BurstSize": 50,
+    "ConnectionLimitPerIPCount": 20,
+    "LimitRatePerSecond": 0,
+    "LimitRateAfter": 0,
+    "MonthlyBandwidthLimit": 0
+  }'
+
+# ---------------------------------------------------------------------------
+# B. Edge rules
+# ---------------------------------------------------------------------------
+
+# 1. Immutable long cache for content-hashed assets (/static/js, css, media).
+#    OverrideCacheTime (edge) + OverrideBrowserCacheTime = 1 year.
+say "Edge rule 1: cache /static/* for 1 year (immutable)"
+add_rule "cache /static/ 1y" '{
+  "ActionType": 3,
+  "ActionParameter1": "31536000",
+  "Enabled": true,
+  "Description": "Cache immutable hashed assets for 1 year",
+  "TriggerMatchingType": 0,
+  "Triggers": [
+    {"Type": 0, "PatternMatchingType": 0, "Parameter1": null,
+     "PatternMatches": ["https://mu.social/static/*", "*/static/*"]}
+  ],
+  "ExtraActions": [
+    {"ActionType": 16, "ActionParameter1": "31536000", "ActionParameter2": null}
+  ]
+}'
+
+# 2. Keep the HTML shell + service worker + manifests short-lived so a deploy
+#    (which also purges) is picked up immediately. 5 minutes.
+say "Edge rule 2: short cache for HTML shell / index"
+add_rule "cache html 5m" '{
+  "ActionType": 3,
+  "ActionParameter1": "300",
+  "Enabled": true,
+  "Description": "Short cache for index.html / SW / manifests",
+  "TriggerMatchingType": 0,
+  "Triggers": [
+    {"Type": 0, "PatternMatchingType": 0, "Parameter1": null,
+     "PatternMatches": ["https://mu.social/", "*/index.html", "*/service-worker.js", "*/manifest.json", "*/robots.txt"]}
+  ]
+}'
+
+# 3. Block obvious non-browser scraper user-agents. Catches naive libraries
+#    only; the JS-executing fleet spoofs real Chrome and is handled by the
+#    per-IP limits above (or Bunny Shield). Extend as you spot offenders.
+#
+#    Bunny allows at most 5 PatternMatches per rule, so the UA list is chunked
+#    into groups of 5, each emitted as its own rule ("... (group N)"). Add or
+#    remove entries in UA_PATTERNS freely; the chunking adjusts automatically.
+UA_PATTERNS='["*python-requests*","*python-httpx*","*Go-http-client*","*Scrapy*","*curl/*","*wget*","*libwww-perl*","*Java/*","*okhttp*","*node-fetch*","*axios*","*spider*"]'
+say "Edge rule 3: block naive scraper user-agents (<=5 patterns/rule)"
+while IFS= read -r body; do
+  [[ -n "$body" ]] || continue
+  add_rule "block scraper UAs" "$body"
+done < <(UAS="$UA_PATTERNS" python3 -c '
+import os, json
+uas = json.loads(os.environ["UAS"])
+chunks = [uas[i:i+5] for i in range(0, len(uas), 5)]
+for idx, ch in enumerate(chunks, 1):
+    print(json.dumps({
+        "ActionType": 4,
+        "Enabled": True,
+        "Description": f"Block scraper user-agents (group {idx})",
+        "TriggerMatchingType": 0,
+        "Triggers": [{"Type": 1, "Parameter1": "User-Agent",
+                      "PatternMatchingType": 0, "PatternMatches": ch}],
+    }))
+')
+
+say "Done. Review the rules in the Bunny dashboard -> Pull Zone -> Edge Rules,"
+echo "and the per-IP limits under Pull Zone -> Security -> Network limits."

--- a/web/robots.disallow.txt
+++ b/web/robots.disallow.txt
@@ -1,0 +1,6 @@
+# Non-production build (staging.mu.social, dev.mu.social). These environments
+# must never be crawled or indexed. Disallow everything for every crawler.
+# (The pull zone also sends X-Robots-Tag: noindex as a second layer, but a
+# blanket Disallow keeps well-behaved crawlers out entirely.)
+User-Agent: *
+Disallow: /

--- a/web/robots.txt
+++ b/web/robots.txt
@@ -1,0 +1,26 @@
+# mu.social is a client-side-rendered single-page app. Every federated
+# permalink (/profile/<handle>, /profile/.../post/<id>, hashtags, DIDs) is an
+# effectively infinite set of URLs, and each one served the full JS bundles.
+# Crawling that space drove ~580 GB/month of origin bandwidth with no SEO
+# value (the pages have no server-rendered content to index anyway).
+#
+# Disallow the high-cardinality, JS-only routes. The home page and static
+# support/marketing pages stay crawlable. If you run bulk data collection,
+# use the AT Protocol firehose instead: https://atproto.com/
+
+User-Agent: *
+Disallow: /profile/
+Disallow: /hashtag/
+Disallow: /topic/
+Disallow: /search
+Disallow: /starter-pack/
+Disallow: /starter-pack-short/
+Disallow: /start/
+Disallow: /feeds
+Disallow: /lists
+Disallow: /notifications
+Disallow: /messages
+Disallow: /moderation
+Disallow: /settings
+Disallow: /intent/
+Allow: /


### PR DESCRIPTION
## Overview

mu.social's Bunny bandwidth (pull zone 5945167) spiked hard over several days.
Investigation of the CDN logs + Plausible showed it's automated traffic in two buckets:

1. **Googlebot crawl trap (the big one, ~580 GB).** mu.social is a client-side
   -rendered SPA, so every federated permalink (`/profile/<handle>`,
   `/profile/.../post/<id>`, hashtags, DIDs — an effectively infinite URL space)
   returns `index.html` and re-downloads the two large JS bundles (~917 kB +
   ~1.29 MB). Top IPs are all in Google's crawler range (66.249.64.0/19).
2. **Scraper/monitor fleet (smaller).** Cloud-hosted clients (Azure + assorted
   hosting) executing JS and hitting the same profile/post URLs — the "US /
   desktop / Chrome" spike in Plausible.

## What this changes

**robots.txt shipped in the web build** (`scripts/bunny_build.sh`, per-env via
`ROBOTS_MODE`):
- **prod** → `web/robots.txt`: disallows the high-cardinality, JS-only routes
  (`/profile/`, `/hashtag/`, `/search`, `/starter-pack/`, ...). This is what
  actually collapses the ~580 GB — it stops the crawl requests. The pages have
  no server-rendered content to index anyway, so there's no SEO loss.
- **staging/dev** → `web/robots.disallow.txt`: `Disallow: /` (kept out of search
  entirely, alongside each zone's existing noindex X-Robots-Tag rule).
- Default is `prod`, so a forgotten flag fails safe (never deindexes prod).

**`scripts/bunny_edge_setup.sh`** — idempotent config applied via the Bunny API:
- Global per-IP network limits: `RequestLimit=4`, `BurstSize=50`,
  `ConnectionLimitPerIPCount=20` (download-speed/monthly caps left unlimited).
- Edge rule: cache `/static/*` 1 year (immutable, hashed assets).
- Edge rule: short-cache the HTML shell / SW / manifests (5 min).
- Edge rules: block naive scraper user-agents (chunked to Bunny's 5-pattern/rule
  limit). Idempotent — matches existing rules by description and updates in
  place, so it's safe to run on every deploy.
- Googlebot is deliberately **not** hard-blocked (robots.txt handles it; a 403
  would risk ranking).
