### PR TITLE
Fix donation button

### DIFF
--- a/src/config/brand.json
+++ b/src/config/brand.json
@@ -97,7 +97,9 @@
     "helpDesk": "https://blueskyweb.zendesk.com/hc/en-us",
     "supportRequest": "https://blueskyweb.zendesk.com/hc/requests/new",
     "download": "https://bsky.app/download",
-    "statusPage": "https://status.bsky.app/"
+    "statusPage": "https://status.bsky.app/",
+    "donate": "https://whydonate.com/fundraising/the-next-era-of-social-media",
+    "feedback": "https://userinput.app/s/did:plc:ooensn4mr5mhznzypvxelfa3/3mnwmwn7sn22u"
   },
   "services": {
     "pds": "https://bsky.social",

--- a/src/view/shell/Drawer.tsx
+++ b/src/view/shell/Drawer.tsx
@@ -12,7 +12,6 @@ import {useLingui} from '@lingui/react'
 import {Plural, Trans} from '@lingui/react/macro'
 import {StackActions, useNavigation} from '@react-navigation/native'
 
-import {FEEDBACK_FORM_URL, HELP_DESK_URL} from '#/lib/constants'
 import {type PressableScale} from '#/lib/custom-animations/PressableScale'
 import {useNavigationTabState} from '#/lib/hooks/useNavigationTabState'
 import {getTabState, TabState} from '#/lib/routes/helpers'
@@ -301,16 +300,11 @@ let DrawerContent = ({}: React.PropsWithoutRef<{}>): React.ReactNode => {
   }, [navigation, setDrawerOpen, ax])
 
   const onPressFeedback = useCallback(() => {
-    Linking.openURL(
-      FEEDBACK_FORM_URL({
-        email: currentAccount?.email,
-        handle: currentAccount?.handle,
-      }),
-    )
-  }, [currentAccount])
+    Linking.openURL(BRAND.links.feedback)
+  }, [])
 
-  const onPressHelp = useCallback(() => {
-    Linking.openURL(HELP_DESK_URL)
+  const onPressDonate = useCallback(() => {
+    Linking.openURL(BRAND.links.donate)
   }, [])
 
   // rendering
@@ -392,7 +386,8 @@ let DrawerContent = ({}: React.PropsWithoutRef<{}>): React.ReactNode => {
 
       <DrawerFooter
         onPressFeedback={onPressFeedback}
-        onPressHelp={onPressHelp}
+        onPressDonate={onPressDonate}
+        hasSession={hasSession}
       />
       <InviteFriendsDialog control={inviteFriendsControl} />
     </View>
@@ -403,10 +398,12 @@ export {DrawerContent}
 
 let DrawerFooter = ({
   onPressFeedback,
-  onPressHelp,
+  onPressDonate,
+  hasSession,
 }: {
   onPressFeedback: () => void
-  onPressHelp: () => void
+  onPressDonate: () => void
+  hasSession: boolean
 }): React.ReactNode => {
   const {_} = useLingui()
   const insets = useSafeAreaInsets()
@@ -426,29 +423,34 @@ let DrawerFooter = ({
         },
       ]}>
       <Button
-        label={_(msg`Send feedback`)}
-        size="small"
-        variant="solid"
-        color="secondary"
-        onPress={onPressFeedback}>
-        <ButtonIcon icon={Message} position="left" />
-        <ButtonText>
-          <Trans>Feedback</Trans>
-        </ButtonText>
-      </Button>
-      <Button
-        label={_(msg`Get help`)}
+        label={_(msg`Donate`)}
         size="small"
         variant="outline"
         color="secondary"
-        onPress={onPressHelp}
+        onPress={onPressDonate}
         style={{
           backgroundColor: 'transparent',
         }}>
         <ButtonText>
-          <Trans>Help</Trans>
+          <Trans>Donate</Trans>
         </ButtonText>
       </Button>
+      {hasSession && (
+        <Button
+          label={_(msg`Send feedback`)}
+          size="small"
+          variant="outline"
+          color="secondary"
+          onPress={onPressFeedback}
+          style={{
+            backgroundColor: 'transparent',
+          }}>
+          <ButtonIcon icon={Message} position="left" />
+          <ButtonText>
+            <Trans>Feedback</Trans>
+          </ButtonText>
+        </Button>
+      )}
     </View>
   )
 }

--- a/src/view/shell/desktop/RightNav.tsx
+++ b/src/view/shell/desktop/RightNav.tsx
@@ -15,7 +15,8 @@ import {
   web,
 } from '#/alf'
 import {AppLanguageDropdown} from '#/components/AppLanguageDropdown'
-import {ButtonText} from '#/components/Button'
+import {ButtonIcon, ButtonText} from '#/components/Button'
+import {Message_Stroke2_Corner0_Rounded as Message} from '#/components/icons/Message'
 import {CENTER_COLUMN_OFFSET} from '#/components/Layout'
 import {InlineLinkText, Link} from '#/components/Link'
 import {Text} from '#/components/Typography'
@@ -64,17 +65,33 @@ export function DesktopRightNav({routeName}: {routeName: string}) {
 
       {hasSession && <DesktopFeeds />}
 
-      <Link
-        to="https://whydonate.com/fundraising/the-next-era-of-social-media"
-        label={_(msg`Donate`)}
-        color="secondary"
-        size="small"
-        variant="solid"
-        style={[a.self_start]}>
-        <ButtonText>
-          <Trans>Donate</Trans>
-        </ButtonText>
-      </Link>
+      <View style={[a.flex_row, a.flex_wrap, a.gap_sm]}>
+        <Link
+          to={BRAND.links.donate}
+          label={_(msg`Donate`)}
+          color="secondary"
+          size="small"
+          variant="outline"
+          style={{backgroundColor: 'transparent'}}>
+          <ButtonText>
+            <Trans>Donate</Trans>
+          </ButtonText>
+        </Link>
+        {hasSession && (
+          <Link
+            to={BRAND.links.feedback}
+            label={_(msg`Send feedback`)}
+            color="secondary"
+            size="small"
+            variant="outline"
+            style={{backgroundColor: 'transparent'}}>
+            <ButtonIcon icon={Message} position="left" />
+            <ButtonText>
+              <Trans>Feedback</Trans>
+            </ButtonText>
+          </Link>
+        )}
+      </View>
 
       <Text style={[a.leading_snug, t.atoms.text_contrast_low]}>
         <InlineLinkText


### PR DESCRIPTION
Removes old "Feedback" and "Help" buttons that pointed to Bluesky channels from mobile nav panel.

Replaces with "Donate" and "Feedback" that point to Eurosky channels. Adds the same Feedback button to the desktop right nav next to Donate. Both urls now live in brand.json links. Feedback only shows when signed in.