### PR TITLE
feat(theme): add purple accent color

### DIFF
--- a/src/config/brand.json
+++ b/src/config/brand.json
@@ -88,6 +88,21 @@
         "primary_900": "#114622",
         "primary_950": "#10391D",
         "primary_975": "#0E2C17"
+      },
+      "purple": {
+        "primary_25":  "#F5F3F7",
+        "primary_50":  "#ECE8F0",
+        "primary_100": "#DED6E7",
+        "primary_200": "#CBBCD9",
+        "primary_300": "#B7A2CD",
+        "primary_400": "#A274D1",
+        "primary_500": "#986DC4",
+        "primary_600": "#7845AA",
+        "primary_700": "#6B4392",
+        "primary_800": "#573975",
+        "primary_900": "#432E58",
+        "primary_950": "#30223D",
+        "primary_975": "#1C1524"
       }
     },
     "defaultAccent": "pink"


### PR DESCRIPTION
Adds a purple accent color option because purple is the best color :purple_heart: 


I picked #986DC4 as the pivot color, which has contrast ratio of 3.94:1 against white text (how it's usually used) and 5.31:1 against black text, and then extended the variation towards white and black by changing the Luminosity value in HSL space.

For contrast ratio comparison with existing accent colors:

| color | against white text | against black text |
|-|-|-|
| pink | 3.79 | 5.54 |
| blue | 3.77 | 5.57 |
| orange | 3.41 | 6.16 |
| green | 4.42 | 4.75 |
| **puple** | **3.94** | **5.31** |

it was picked to have a similar color ratio as the existing ones, although only the green one currently conforms to WCAG standards when used with the rest of the theme.

I based my contribution on this previous PR: #159 

Here are some screencaps of the main UI in light and dark mode
<img width="1175" height="741" alt="image" src="https://github.com/user-attachments/assets/7188c309-3765-4fec-a4b1-802f9c68fa85" />

<img width="1119" height="724" alt="image" src="https://github.com/user-attachments/assets/b04b8555-85e0-41cf-a5ac-8c082fd5a3b7" />
