### PR TITLE
newsroom discovery: link posts to newsrooms and rank the front page by engagement

### DIFF
--- a/src/components/Post/Embed/index.tsx
+++ b/src/components/Post/Embed/index.tsx
@@ -29,6 +29,7 @@ import {RichText} from '#/components/RichText'
 import {Embed as StarterPackCard} from '#/components/StarterPack/StarterPackCard'
 import {SubtleHover} from '#/components/SubtleHover'
 import {matchCustomEmbed} from '#/features/customEmbeds/registry'
+import {NewsroomLinkChip} from '#/features/newsrooms/components/NewsroomLinkChip'
 import * as bsky from '#/types/bsky'
 import {
   type Embed as TEmbed,
@@ -151,6 +152,8 @@ function MediaEmbed({
             onOpen={rest.onOpen}
             style={[a.mt_sm, rest.style]}
           />
+          {/* EUROSKY: links a post to the newsroom of the org it links to. */}
+          <NewsroomLinkChip url={embed.view.external.uri} style={[a.mt_xs]} />
         </ContentHider>
       )
     }

--- a/src/features/newsrooms/NewsroomScreen.tsx
+++ b/src/features/newsrooms/NewsroomScreen.tsx
@@ -12,9 +12,11 @@ import {PostFeed} from '#/view/com/posts/PostFeed'
 import {type ListMethods} from '#/view/com/util/List'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
 import {atoms as a, useLayoutBreakpoints, useTheme} from '#/alf'
-import {Button, ButtonIcon} from '#/components/Button'
+import {Button, ButtonIcon, ButtonText} from '#/components/Button'
+import {Newspaper_Stroke2_Corner2_Rounded as NewsFeedIcon} from '#/components/icons/Newspaper'
 import {Newspaper2_Stroke2_Corner2_Rounded as NewsroomsIcon} from '#/components/icons/Newspaper2'
 import * as Layout from '#/components/Layout'
+import {Link} from '#/components/Link'
 import {Loader} from '#/components/Loader'
 import * as Menu from '#/components/Menu'
 import {Text} from '#/components/Typography'
@@ -107,6 +109,20 @@ export function NewsroomScreen({route, navigation}: Props) {
             <Trans>Mu Newsrooms</Trans>
           </Layout.Header.TitleText>
         </Layout.Header.Content>
+        {/* Mirrors the news feed header's "Newsrooms" link, so the two news
+         * surfaces cross-link both ways. Sits outside Header.Slot: slots are
+         * fixed-width squares and this button carries a text label. */}
+        <Link
+          testID="newsroomNewsFeedBtn"
+          to="/news"
+          label={l`Open your news feed`}
+          size="small"
+          color="secondary">
+          <ButtonIcon icon={NewsFeedIcon} />
+          <ButtonText>
+            <Trans>News</Trans>
+          </ButtonText>
+        </Link>
         {/* The org switcher scrolls away with the feed; this menu keeps
          * switching newsrooms one tap away from anywhere on the page. */}
         <Layout.Header.Slot>
@@ -177,21 +193,34 @@ export function NewsroomScreen({route, navigation}: Props) {
              * is hidden, fall back to rendering it inline above the feed. */}
             {!rightNavVisible && (
               <View style={[a.pb_md]}>
-                <NewsroomRightRail />
+                <NewsroomRightRail inline />
               </View>
             )}
             {/* Native social layer: the conversation around the journalism. */}
             <View
               style={[
+                a.flex_row,
+                a.align_center,
+                a.gap_sm,
                 a.px_lg,
-                a.pt_lg,
-                a.pb_sm,
+                a.py_xl,
                 a.border_t,
+                a.border_b,
                 t.atoms.border_contrast_low,
               ]}>
+              <NewsroomsIcon
+                size="lg"
+                style={{color: publisher.accent ?? t.palette.primary_500}}
+              />
               <Text
                 emoji
-                style={[a.text_xs, a.font_bold, t.atoms.text_contrast_medium]}>
+                style={[
+                  a.flex_1,
+                  a.text_2xl,
+                  a.font_bold,
+                  a.leading_tight,
+                  t.atoms.text,
+                ]}>
                 <Trans>From {publisherName} and its reporters</Trans>
               </Text>
             </View>

--- a/src/features/newsrooms/README.md
+++ b/src/features/newsrooms/README.md
@@ -64,7 +64,10 @@ the rail is where they surface as people), then the cross-network context: a
 "Your News" link to the custom news feed (`/news`) and the live sports widget
 (`features/liveSports`). It renders in the shell's right column on wide screens
 (`RightNav` branches on the route) and inline above the conversation when that
-column is hidden; it resolves the focused org from the navigation state.
+column is hidden - where the rail adapts to the scroll: the reporters list
+collapses to a preview of the first few, fading out under a gradient with a
+"Show all" toggle, and the "Your News" callout tightens to a single tappable
+row. It resolves the focused org from the navigation state.
 
 ## RSS
 
@@ -86,20 +89,38 @@ feed simply renders no front page - the page still works as the conversation.
 ## Roadmap
 
 - A real entry point into `/newsroom` (left nav item); today the hub is reached
-  by URL, the news feed's cross-links, and publisher profiles.
+  by URL, the news feed's cross-links, publisher profiles, and the link chip on
+  posts (below).
 - Working category filter chips (filter both articles and the conversation).
 - Production RSS edge proxy (see `services/rss/README.md`).
 - Later, behind real demand: more `NewsroomSource` adapters (podcast, YouTube),
   an aggregate dashboard across newsrooms.
+
+## Discovery from posts
+
+Newsrooms surface from ordinary posts across the app: when any post's external
+link embed points at a registered publisher's site (matched against the
+registry's `domains`, subdomains included), the embed grows a small accent-tinted
+chip (`components/NewsroomLinkChip.tsx`) linking to that org's newsroom. The
+chip renders inside the embed's `ContentHider`, so moderated links hide it too.
 
 ## Article anchoring
 
 Each article maps to a Bluesky thread by link match: `useArticleDiscussionQuery`
 searches posts for the article URL and, when one of them is the publisher's own
 post, treats it as the article's canonical thread (`anchor`). The discussion
-block pins it first and its "Join the conversation" link lands in that thread,
-"Share this story" becomes a quote of it (so shares grow one conversation
-instead of scattering), and secondary articles show their post counts. The
+block pins the anchor first - the publisher's post always wins the top slot -
+and ranks the rest by their Atmosphere interactions (likes, reposts, replies,
+quotes). The anchor also drives the social plumbing: "Join the conversation"
+opens the composer as a reply into that thread, "Open the thread" beside it
+links into the thread itself, and "Share this story" becomes a quote of it, so
+all three grow one conversation instead of scattering. Every
+navigation into the discussion - the block's header, and the post counts on
+secondary articles - lands on a URL search showing all posts that feature the
+article. The front page's featured story follows the same signal:
+`useArticleDiscussionsQuery` totals each article's interactions,
+decayed with a 24h half-life so fresher news can take the hero slot, and ties
+fall back to newest. The
 match depends on the publisher actually posting its articles; an explicit
 article<->thread pairing (e.g. a record the publisher writes) can replace the
 heuristic later without changing the UI.

--- a/src/features/newsrooms/accent.ts
+++ b/src/features/newsrooms/accent.ts
@@ -1,0 +1,44 @@
+import {type Theme, utils} from '#/alf'
+
+/** WCAG AA for normal-size text. */
+const MIN_CONTRAST = 4.5
+
+/** Points of HSL lightness the accent may shift before it stops reading as the brand. */
+const MAX_SHIFT = 45
+const SHIFT_STEP = 5
+
+/**
+ * A publisher's brand color, shifted in lightness until it is legible against
+ * the current background. Falls back to the theme accent when no shift within
+ * `MAX_SHIFT` clears `MIN_CONTRAST`.
+ */
+export function readableAccent(accent: string | undefined, t: Theme): string {
+  if (!accent) return t.palette.primary_500
+
+  const background = t.atoms.bg.backgroundColor
+  if (utils.contrastRatio(accent, background) === null) {
+    return t.palette.primary_500
+  }
+
+  // Shift away from the background: lighter on dark themes, darker on light.
+  const towardLight = isDarkBackground(background)
+  for (let shift = 0; shift <= MAX_SHIFT; shift += SHIFT_STEP) {
+    const candidate =
+      shift === 0
+        ? accent
+        : towardLight
+          ? utils.lighten(accent, shift)
+          : utils.darken(accent, shift)
+    const ratio = utils.contrastRatio(candidate, background)
+    if (ratio !== null && ratio >= MIN_CONTRAST) return candidate
+  }
+
+  return t.palette.primary_500
+}
+
+function isDarkBackground(background: string): boolean {
+  const vsWhite = utils.contrastRatio(background, '#FFFFFF')
+  const vsBlack = utils.contrastRatio(background, '#000000')
+  if (vsWhite === null || vsBlack === null) return false
+  return vsWhite > vsBlack
+}

--- a/src/features/newsrooms/components/ArticleDiscussion.tsx
+++ b/src/features/newsrooms/components/ArticleDiscussion.tsx
@@ -72,6 +72,13 @@ export function ArticleDiscussion({
       })
     : undefined
 
+  /*
+   * A thread gate on the canonical thread would reject the reply after the
+   * composer had already taken it, so offer reading the thread instead.
+   */
+  const canReply = !!visibleAnchor && !visibleAnchor.post.viewer?.replyDisabled
+  const showAnchorActions = canReply || !!anchorPath
+
   // "Join the conversation" opens the composer as a reply to the canonical
   // thread, so joining grows the one conversation instead of starting another.
   function onJoinConversation() {
@@ -121,26 +128,38 @@ export function ArticleDiscussion({
         </Fragment>
       ))}
 
-      {visibleAnchor ? (
+      {showAnchorActions ? (
         <View style={[a.flex_row, a.align_center, a.gap_lg]}>
-          <Button
-            label={l`Reply to the discussion thread`}
-            onPress={onJoinConversation}
-            style={[a.self_start]}>
-            <Text
-              style={[a.text_sm, a.font_bold, {color: t.palette.primary_500}]}>
-              <Trans>Join the conversation</Trans>
-            </Text>
-          </Button>
-          {/* Composing is the primary action; the quiet link beside it opens
-              the canonical thread for reading. */}
+          {canReply && (
+            <Button
+              label={l`Reply to the discussion thread`}
+              onPress={onJoinConversation}
+              style={[a.self_start]}>
+              <Text
+                style={[
+                  a.text_sm,
+                  a.font_bold,
+                  {color: t.palette.primary_500},
+                ]}>
+                <Trans>Join the conversation</Trans>
+              </Text>
+            </Button>
+          )}
+          {/* Composing is the primary action where it is open to us; otherwise
+              reading the canonical thread is all that is left. */}
           {anchorPath && (
             <Link
               to={anchorPath}
               label={l`Open the discussion thread`}
               style={[a.self_start]}>
               <Text
-                style={[a.text_sm, a.font_bold, t.atoms.text_contrast_medium]}>
+                style={[
+                  a.text_sm,
+                  a.font_bold,
+                  canReply
+                    ? t.atoms.text_contrast_medium
+                    : {color: t.palette.primary_500},
+                ]}>
                 <Trans>Open the thread</Trans>
               </Text>
             </Link>
@@ -233,13 +252,9 @@ function DiscussionPost({
   )
 }
 
+// Only the counts the row actually renders, so it is never an empty padded row.
 function hasEngagement(post: AppBskyFeedDefs.PostView): boolean {
-  return !!(
-    post.repostCount ||
-    post.likeCount ||
-    post.replyCount ||
-    post.quoteCount
-  )
+  return !!(post.repostCount || post.likeCount || post.replyCount)
 }
 
 function Stat({

--- a/src/features/newsrooms/components/ArticleDiscussion.tsx
+++ b/src/features/newsrooms/components/ArticleDiscussion.tsx
@@ -9,12 +9,14 @@ import {
 import {plural} from '@lingui/core/macro'
 import {Trans, useLingui} from '@lingui/react/macro'
 
+import {useOpenComposer} from '#/lib/hooks/useOpenComposer'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {postUriToRelativePath} from '#/lib/strings/url-helpers'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {PreviewableUserAvatar} from '#/view/com/util/UserAvatar'
 import {atoms as a, useTheme} from '#/alf'
+import {Button} from '#/components/Button'
 import {Divider} from '#/components/Divider'
 import {Bubble_Stroke2_Corner2_Rounded as Bubble} from '#/components/icons/Bubble'
 import {Heart2_Stroke2_Corner0_Rounded as Heart} from '#/components/icons/Heart2'
@@ -23,8 +25,9 @@ import {Link} from '#/components/Link'
 import {ContentHider} from '#/components/moderation/ContentHider'
 import {PostAlerts} from '#/components/moderation/PostAlerts'
 import {Text} from '#/components/Typography'
-import {articleDiscussionPath} from '../discussion'
+import {articleSearchPath} from '../discussion'
 import {useArticleDiscussionQuery} from '../queries'
+import {toSingleParagraph} from '../text'
 
 const SHOWN = 3
 
@@ -43,6 +46,7 @@ export function ArticleDiscussion({
   const t = useTheme()
   const {t: l} = useLingui()
   const moderationOpts = useModerationOpts()
+  const {openComposer} = useOpenComposer()
   const {data, isLoading} = useArticleDiscussionQuery({url, publisherDid})
 
   /*
@@ -57,15 +61,36 @@ export function ArticleDiscussion({
   const posts = moderatedPosts.slice(0, SHOWN)
   if (!posts.length) return null
 
-  // The publisher's own post of the article is its canonical thread; "see all"
-  // lands there rather than on a search page, unless moderation filtered it.
+  // The publisher's own post of the article is its canonical thread; joining
+  // the conversation replies there, unless moderation filtered it.
   const visibleAnchor = data.anchor
-    ? moderatedPosts.find(({post}) => post.uri === data.anchor?.uri)?.post
+    ? moderatedPosts.find(({post}) => post.uri === data.anchor?.uri)
     : undefined
-  const {path: discussionPath, isAnchor} = articleDiscussionPath({
-    url,
-    anchor: visibleAnchor,
-  })
+  const anchorPath = visibleAnchor
+    ? postUriToRelativePath(visibleAnchor.post.uri, {
+        handle: visibleAnchor.post.author.handle,
+      })
+    : undefined
+
+  // "Join the conversation" opens the composer as a reply to the canonical
+  // thread, so joining grows the one conversation instead of starting another.
+  function onJoinConversation() {
+    if (!visibleAnchor) return
+    const {post, moderation} = visibleAnchor
+    const record = post.record as AppBskyFeedPost.Record
+    openComposer({
+      replyTo: {
+        uri: post.uri,
+        cid: post.cid,
+        text: typeof record.text === 'string' ? record.text : '',
+        author: post.author,
+        embed: post.embed,
+        moderation,
+        langs: record.langs,
+      },
+      logContext: 'PostReply',
+    })
+  }
 
   return (
     <View
@@ -78,9 +103,16 @@ export function ArticleDiscussion({
         t.atoms.border_contrast_low,
         t.atoms.bg_contrast_25,
       ]}>
-      <Text style={[a.text_xs, a.font_bold, t.atoms.text_contrast_medium]}>
-        <Trans>This story in the Atmosphere</Trans>
-      </Text>
+      {/* The header is the door to the full conversation: every post that
+          features this article, not just the few shown here. */}
+      <Link
+        to={articleSearchPath(url)}
+        label={l`See all posts featuring this article`}
+        style={[a.self_start]}>
+        <Text style={[a.text_xs, a.font_bold, t.atoms.text_contrast_medium]}>
+          <Trans>This story in the Atmosphere</Trans>
+        </Text>
+      </Link>
 
       {posts.map(({post, moderation}, i) => (
         <Fragment key={post.uri}>
@@ -89,26 +121,48 @@ export function ArticleDiscussion({
         </Fragment>
       ))}
 
-      <Link
-        to={discussionPath}
-        label={
-          isAnchor
-            ? l`Open the discussion thread`
-            : l`See all posts about this article`
-        }
-        style={[a.self_start]}>
-        <Text style={[a.text_sm, a.font_bold, {color: t.palette.primary_500}]}>
-          {isAnchor ? (
-            <Trans>Join the conversation</Trans>
-          ) : data.total > SHOWN ? (
-            <Trans>
-              See all {plural(data.total, {one: '# post', other: '# posts'})}
-            </Trans>
-          ) : (
-            <Trans>See the conversation</Trans>
+      {visibleAnchor ? (
+        <View style={[a.flex_row, a.align_center, a.gap_lg]}>
+          <Button
+            label={l`Reply to the discussion thread`}
+            onPress={onJoinConversation}
+            style={[a.self_start]}>
+            <Text
+              style={[a.text_sm, a.font_bold, {color: t.palette.primary_500}]}>
+              <Trans>Join the conversation</Trans>
+            </Text>
+          </Button>
+          {/* Composing is the primary action; the quiet link beside it opens
+              the canonical thread for reading. */}
+          {anchorPath && (
+            <Link
+              to={anchorPath}
+              label={l`Open the discussion thread`}
+              style={[a.self_start]}>
+              <Text
+                style={[a.text_sm, a.font_bold, t.atoms.text_contrast_medium]}>
+                <Trans>Open the thread</Trans>
+              </Text>
+            </Link>
           )}
-        </Text>
-      </Link>
+        </View>
+      ) : (
+        <Link
+          to={articleSearchPath(url)}
+          label={l`See all posts featuring this article`}
+          style={[a.self_start]}>
+          <Text
+            style={[a.text_sm, a.font_bold, {color: t.palette.primary_500}]}>
+            {data.total > SHOWN ? (
+              <Trans>
+                See all {plural(data.total, {one: '# post', other: '# posts'})}
+              </Trans>
+            ) : (
+              <Trans>See the conversation</Trans>
+            )}
+          </Text>
+        </Link>
+      )}
     </View>
   )
 }
@@ -123,7 +177,8 @@ function DiscussionPost({
   const t = useTheme()
   const author = post.author
   const record = post.record as AppBskyFeedPost.Record
-  const text = typeof record.text === 'string' ? record.text : ''
+  const text =
+    typeof record.text === 'string' ? toSingleParagraph(record.text) : ''
   const path = postUriToRelativePath(post.uri, {handle: author.handle})
   const contentModui = moderation.ui('contentView')
   const displayName = sanitizeDisplayName(
@@ -179,7 +234,12 @@ function DiscussionPost({
 }
 
 function hasEngagement(post: AppBskyFeedDefs.PostView): boolean {
-  return !!(post.repostCount || post.likeCount || post.replyCount)
+  return !!(
+    post.repostCount ||
+    post.likeCount ||
+    post.replyCount ||
+    post.quoteCount
+  )
 }
 
 function Stat({

--- a/src/features/newsrooms/components/NewsroomFrontPage.tsx
+++ b/src/features/newsrooms/components/NewsroomFrontPage.tsx
@@ -11,10 +11,11 @@ import {EditBig_Stroke2_Corner2_Rounded as ComposeIcon} from '#/components/icons
 import {InlineLinkText, Link} from '#/components/Link'
 import {Loader} from '#/components/Loader'
 import {Text} from '#/components/Typography'
-import {articleDiscussionPath} from '../discussion'
+import {articleSearchPath} from '../discussion'
 import {getPublisherRssUrls, type NewsroomPublisher} from '../publishers'
 import {
   useArticleDiscussionQuery,
+  useArticleDiscussionsQuery,
   useOgImageQuery,
   useRssArticlesQuery,
 } from '../queries'
@@ -24,10 +25,19 @@ import {ArticleDiscussion} from './ArticleDiscussion'
 export function NewsroomFrontPage({publisher}: {publisher: NewsroomPublisher}) {
   const urls = getPublisherRssUrls(publisher)
   const {data: articles, isLoading} = useRssArticlesQuery({urls})
+  const discussions = useArticleDiscussionsQuery({
+    urls: articles?.map(item => item.link) ?? [],
+    publisherDid: publisher.did,
+  })
 
   if (urls.length === 0) return null
 
-  if (isLoading) {
+  /*
+   * Featuring depends on every article's interaction total, so the loader
+   * holds until the discussion lookups settle too - otherwise the hero would
+   * visibly swap once the counts arrive.
+   */
+  if (isLoading || discussions.some(q => q.isLoading)) {
     return (
       <View style={[a.px_lg, a.py_xl, a.align_center]}>
         <Loader size="md" />
@@ -39,7 +49,24 @@ export function NewsroomFrontPage({publisher}: {publisher: NewsroomPublisher}) {
   // render nothing rather than an empty shell.
   if (!articles?.length) return null
 
-  const [hero, ...rest] = articles
+  /*
+   * The featured story is whichever article drew the most Atmosphere
+   * interactions, discounted by age so last week's viral piece eventually
+   * cedes the hero slot to fresher news. Ties (including all-zero, e.g. when
+   * search is down) fall back to the feed's newest-first order, which the
+   * rest keep.
+   */
+  const now = Date.now()
+  const scores = new Map(
+    articles.map((item, i) => [
+      item,
+      heroScore(item, discussions[i]?.data?.interactions ?? 0, now),
+    ]),
+  )
+  const hero = articles.reduce((top, item) =>
+    (scores.get(item) ?? 0) > (scores.get(top) ?? 0) ? item : top,
+  )
+  const rest = articles.filter(item => item !== hero)
 
   return (
     <View style={[a.px_lg, a.pt_sm, a.pb_lg, a.gap_md]}>
@@ -171,12 +198,7 @@ function SecondaryArticle({
           <ArticleMeta
             item={item}
             discussionCount={discussion?.total}
-            discussionPath={
-              articleDiscussionPath({
-                url: item.link,
-                anchor: discussion?.anchor,
-              }).path
-            }
+            discussionPath={articleSearchPath(item.link)}
           />
         </View>
       </View>
@@ -308,6 +330,24 @@ function ArticleMeta({
       )}
     </Text>
   )
+}
+
+/** How long an interaction keeps half its weight in the hero choice. */
+const HERO_HALF_LIFE_MS = 24 * 60 * 60 * 1000
+
+/**
+ * An article's claim on the hero slot: its Atmosphere interactions decayed
+ * exponentially by age. Undated articles count as two half-lives old, so a
+ * dated story with comparable engagement beats them.
+ */
+function heroScore(item: RssItem, interactions: number, now: number): number {
+  const published = item.publishedAt
+    ? new Date(item.publishedAt).getTime()
+    : NaN
+  const ageMs = Number.isNaN(published)
+    ? HERO_HALF_LIFE_MS * 2
+    : Math.max(0, now - published)
+  return interactions * 0.5 ** (ageMs / HERO_HALF_LIFE_MS)
 }
 
 function safeHostname(url: string): string {

--- a/src/features/newsrooms/components/NewsroomFrontPage.tsx
+++ b/src/features/newsrooms/components/NewsroomFrontPage.tsx
@@ -305,7 +305,7 @@ function ArticleMeta({
   })
 
   return (
-    <Text style={[a.text_xs, t.atoms.text_contrast_low]}>
+    <Text style={[a.text_xs, t.atoms.text_contrast_medium]}>
       {hostname}
       {!!item.publishedAt && (
         <>

--- a/src/features/newsrooms/components/NewsroomLinkChip.tsx
+++ b/src/features/newsrooms/components/NewsroomLinkChip.tsx
@@ -1,0 +1,84 @@
+import {type StyleProp, View, type ViewStyle} from 'react-native'
+import {Trans, useLingui} from '@lingui/react/macro'
+
+import {useProfileQuery} from '#/state/queries/profile'
+import {atoms as a, useTheme} from '#/alf'
+import {Newspaper2_Stroke2_Corner2_Rounded as NewsroomIcon} from '#/components/icons/Newspaper2'
+import {Link} from '#/components/Link'
+import {Text} from '#/components/Typography'
+import {
+  getNewsroomPublisherByUrl,
+  getPublisherName,
+  type NewsroomPublisher,
+} from '../publishers'
+
+/**
+ * A small pill rendered under a post's external link embed when the link
+ * points at a registered publisher's site, connecting the post back to that
+ * org's newsroom. Renders nothing for unregistered domains, so call sites can
+ * include it unconditionally.
+ */
+export function NewsroomLinkChip({
+  url,
+  style,
+}: {
+  url: string
+  style?: StyleProp<ViewStyle>
+}) {
+  const publisher = getNewsroomPublisherByUrl(url)
+  if (!publisher) return null
+  return <Chip publisher={publisher} style={style} />
+}
+
+/*
+ * A separate component from the lookup so hooks only run for posts that
+ * actually match a publisher; the profile query supplies the org's live
+ * display name.
+ */
+function Chip({
+  publisher,
+  style,
+}: {
+  publisher: NewsroomPublisher
+  style?: StyleProp<ViewStyle>
+}) {
+  const t = useTheme()
+  const {t: l} = useLingui()
+  const {data: profile} = useProfileQuery({did: publisher.did})
+  const name = getPublisherName(profile)
+  const accent = publisher.accent ?? t.palette.primary_500
+
+  return (
+    <View style={[a.flex_row, style]}>
+      <Link
+        to={`/newsroom/${publisher.did}`}
+        label={name ? l`Visit the ${name} newsroom` : l`Visit this newsroom`}
+        style={[a.rounded_full]}>
+        {({hovered, pressed}) => (
+          <View
+            style={[
+              a.flex_row,
+              a.align_center,
+              a.gap_xs,
+              a.rounded_full,
+              a.border,
+              a.px_sm,
+              a.py_2xs,
+              a.transition_color,
+              hovered || pressed
+                ? {borderColor: accent + '80', backgroundColor: accent + '26'}
+                : {borderColor: accent + '4D', backgroundColor: accent + '14'},
+            ]}>
+            <NewsroomIcon size="xs" style={{color: accent}} />
+            <Text
+              emoji
+              numberOfLines={1}
+              style={[a.text_xs, a.font_bold, a.leading_snug, {color: accent}]}>
+              {name ? <Trans>{name} Newsroom</Trans> : <Trans>Newsroom</Trans>}
+            </Text>
+          </View>
+        )}
+      </Link>
+    </View>
+  )
+}

--- a/src/features/newsrooms/components/NewsroomLinkChip.tsx
+++ b/src/features/newsrooms/components/NewsroomLinkChip.tsx
@@ -6,6 +6,7 @@ import {atoms as a, useTheme} from '#/alf'
 import {Newspaper2_Stroke2_Corner2_Rounded as NewsroomIcon} from '#/components/icons/Newspaper2'
 import {Link} from '#/components/Link'
 import {Text} from '#/components/Typography'
+import {readableAccent} from '../accent'
 import {
   getNewsroomPublisherByUrl,
   getPublisherName,
@@ -46,7 +47,7 @@ function Chip({
   const {t: l} = useLingui()
   const {data: profile} = useProfileQuery({did: publisher.did})
   const name = getPublisherName(profile)
-  const accent = publisher.accent ?? t.palette.primary_500
+  const accent = readableAccent(publisher.accent, t)
 
   return (
     <View style={[a.flex_row, style]}>

--- a/src/features/newsrooms/components/NewsroomMasthead.tsx
+++ b/src/features/newsrooms/components/NewsroomMasthead.tsx
@@ -37,7 +37,7 @@ export function NewsroomMasthead({publisher}: {publisher: NewsroomPublisher}) {
       {publisher.categories.map(category => (
         <View
           key={category}
-          style={[a.px_md, a.py_xs, a.rounded_full, t.atoms.bg_contrast_25]}>
+          style={[a.px_md, a.py_xs, a.rounded_full, t.atoms.bg_contrast_50]}>
           <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
             {category}
           </Text>
@@ -90,7 +90,7 @@ export function NewsroomMasthead({publisher}: {publisher: NewsroomPublisher}) {
                 {profile && <PublisherVerification profile={profile} />}
               </View>
               {!!profile && (
-                <Text style={[a.text_xs, t.atoms.text_contrast_low]}>
+                <Text style={[a.text_xs, t.atoms.text_contrast_medium]}>
                   {sanitizeHandle(profile.handle, '@')}
                 </Text>
               )}

--- a/src/features/newsrooms/components/NewsroomMasthead.tsx
+++ b/src/features/newsrooms/components/NewsroomMasthead.tsx
@@ -15,6 +15,7 @@ import * as ProfileCard from '#/components/ProfileCard'
 import {Text} from '#/components/Typography'
 import {VerificationCheckButton} from '#/components/verification/VerificationCheckButton'
 import {getPublisherName, type NewsroomPublisher} from '../publishers'
+import {toSingleParagraph} from '../text'
 
 export function NewsroomMasthead({publisher}: {publisher: NewsroomPublisher}) {
   const t = useTheme()
@@ -25,7 +26,7 @@ export function NewsroomMasthead({publisher}: {publisher: NewsroomPublisher}) {
   // with their live avatar, name, and bio.
   const {data: profile} = useProfileQuery({did: publisher.did})
   const name = getPublisherName(profile)
-  const bio = profile?.description?.trim()
+  const bio = profile?.description && toSingleParagraph(profile.description)
   const profilePath = makeProfileLink({
     did: publisher.did,
     handle: profile?.handle ?? publisher.did,

--- a/src/features/newsrooms/components/NewsroomRightRail.tsx
+++ b/src/features/newsrooms/components/NewsroomRightRail.tsx
@@ -1,4 +1,6 @@
+import {useState} from 'react'
 import {View} from 'react-native'
+import {LinearGradient} from 'expo-linear-gradient'
 import {type AppBskyActorDefs} from '@atproto/api'
 import {Trans, useLingui} from '@lingui/react/macro'
 import {useNavigationState} from '@react-navigation/native'
@@ -12,7 +14,13 @@ import {profilesQueryKey} from '#/state/queries/profile'
 import {useAgent} from '#/state/session'
 import * as ModuleHeader from '#/screens/Search/components/ModuleHeader'
 import {atoms as a, useTheme} from '#/alf'
-import {ButtonText} from '#/components/Button'
+import {transparentifyColor} from '#/alf/util/colorGeneration'
+import {Button, ButtonText} from '#/components/Button'
+import {
+  ChevronBottom_Stroke2_Corner0_Rounded as ChevronDownIcon,
+  ChevronRight_Stroke2_Corner0_Rounded as ChevronRightIcon,
+  ChevronTop_Stroke2_Corner0_Rounded as ChevronUpIcon,
+} from '#/components/icons/Chevron'
 import {Newspaper_Stroke2_Corner2_Rounded as NewspaperIcon} from '#/components/icons/Newspaper'
 import {PersonGroup_Stroke2_Corner2_Rounded as PersonGroupIcon} from '#/components/icons/Person'
 import {Link} from '#/components/Link'
@@ -25,12 +33,25 @@ import {
   type NewsroomPublisher,
 } from '../publishers'
 
+/** How many reporters the collapsed module previews. */
+const COLLAPSED_SHOWN = 2
+
 /**
  * The newsroom hub's right column: the focused org's reporters, then the
  * cross-network context that sits beside any org - the broader curated news
  * feed and live sports.
  */
-export function NewsroomRightRail() {
+export function NewsroomRightRail({
+  inline = false,
+}: {
+  /**
+   * Adapts the rail for rendering inline in the scroll (narrow screens):
+   * the reporters list collapses to a preview and the news callout tightens
+   * to a single row, so the rail does not push the conversation far down.
+   * The desktop right column has the vertical room for the full modules.
+   */
+  inline?: boolean
+}) {
   // The rail renders in the shell's right column on desktop and inline in the
   // screen otherwise, so it resolves the focused org from the navigation state
   // instead of threading a prop through the shell.
@@ -46,8 +67,8 @@ export function NewsroomRightRail() {
 
   return (
     <View>
-      <ReportersModule publisher={publisher} />
-      <NewsModule />
+      <ReportersModule publisher={publisher} collapsible={inline} />
+      <NewsModule compact={inline} />
       <ExploreLiveSportsWidget />
     </View>
   )
@@ -57,10 +78,19 @@ export function NewsroomRightRail() {
  * The focused org's reporters as followable profiles. The merged feed blends
  * their posts in anonymously; this is where they surface as people.
  */
-function ReportersModule({publisher}: {publisher: NewsroomPublisher}) {
-  const {t: l} = useLingui()
+function ReportersModule({
+  publisher,
+  collapsible = false,
+}: {
+  publisher: NewsroomPublisher
+  /** Hides the roster behind the header until tapped; see the rail's prop. */
+  collapsible?: boolean
+}) {
+  const t = useTheme()
+  const {i18n, t: l} = useLingui()
   const moderationOpts = useModerationOpts()
   const {profilesByDid, isLoading} = useReporterProfiles(publisher.reporterDids)
+  const [expanded, setExpanded] = useState(false)
 
   // Stay quiet until everything is loaded - same rule as the front page.
   if (!publisher.reporterDids.length || isLoading || !moderationOpts)
@@ -72,43 +102,129 @@ function ReportersModule({publisher}: {publisher: NewsroomPublisher}) {
     .filter(profile => !!profile)
   if (!profiles.length) return null
 
+  // Collapsed is a preview, not a closed drawer: the first few reporters keep
+  // the module inviting while a long roster stays out of the way.
+  const canToggle = collapsible && profiles.length > COLLAPSED_SHOWN
+  const shown =
+    canToggle && !expanded ? profiles.slice(0, COLLAPSED_SHOWN) : profiles
+
+  const accent = publisher.accent ?? t.palette.primary_500
+
+  const header = (
+    <ModuleHeader.Container
+      bottomBorder
+      style={canToggle ? a.flex_1 : undefined}>
+      {/* The icon carries the org accent, matching the conversation heading;
+       * ModuleHeader.Icon renders in the text color, so place the icon
+       * directly with its sizing. */}
+      <PersonGroupIcon size="lg" style={{color: accent, marginLeft: -2}} />
+      {/* Bigger than the stock module title so the section reads at the same
+       * level as the page's other headings. */}
+      <ModuleHeader.TitleText style={[a.text_2xl, a.font_bold]}>
+        {l`Reporters`}
+      </ModuleHeader.TitleText>
+      {canToggle && (
+        <>
+          <Text style={[a.text_md, t.atoms.text_contrast_medium]}>
+            {i18n.number(profiles.length)}
+          </Text>
+          {expanded ? (
+            <ChevronUpIcon size="sm" style={t.atoms.text_contrast_low} />
+          ) : (
+            <ChevronDownIcon size="sm" style={t.atoms.text_contrast_low} />
+          )}
+        </>
+      )}
+    </ModuleHeader.Container>
+  )
+
   return (
     <View style={[a.pb_xl]}>
-      <ModuleHeader.Container>
-        <ModuleHeader.Icon icon={PersonGroupIcon} />
-        <ModuleHeader.TitleText>{l`Reporters`}</ModuleHeader.TitleText>
-      </ModuleHeader.Container>
-      <View style={[a.px_lg, a.gap_lg]}>
-        {profiles.map(profile => (
-          <ProfileCard.Link key={profile.did} profile={profile}>
-            <ProfileCard.Outer>
-              <ProfileCard.Header>
-                <ProfileCard.Avatar
+      {canToggle ? (
+        <Button
+          label={
+            expanded
+              ? l`Show fewer reporters`
+              : l`Show all ${i18n.number(profiles.length)} reporters`
+          }
+          onPress={() => setExpanded(v => !v)}
+          style={[a.w_full]}>
+          {header}
+        </Button>
+      ) : (
+        header
+      )}
+      <View style={[a.relative]}>
+        <View style={[a.px_lg, a.pt_md, a.gap_lg]}>
+          {shown.map(profile => (
+            <ProfileCard.Link key={profile.did} profile={profile}>
+              <ProfileCard.Outer>
+                <ProfileCard.Header>
+                  <ProfileCard.Avatar
+                    profile={profile}
+                    moderationOpts={moderationOpts}
+                  />
+                  <ProfileCard.NameAndHandle
+                    profile={profile}
+                    moderationOpts={moderationOpts}
+                  />
+                  {/* Icon-only so the button does not crowd the narrow rail. */}
+                  <ProfileCard.FollowButton
+                    profile={profile}
+                    moderationOpts={moderationOpts}
+                    logContext="ProfileCard"
+                    shape="round"
+                    size="tiny"
+                  />
+                </ProfileCard.Header>
+                <ProfileCard.Labels
                   profile={profile}
                   moderationOpts={moderationOpts}
                 />
-                <ProfileCard.NameAndHandle
-                  profile={profile}
-                  moderationOpts={moderationOpts}
-                />
-                {/* Icon-only so the button does not crowd the narrow rail. */}
-                <ProfileCard.FollowButton
-                  profile={profile}
-                  moderationOpts={moderationOpts}
-                  logContext="ProfileCard"
-                  shape="round"
-                  size="tiny"
-                />
-              </ProfileCard.Header>
-              <ProfileCard.Labels
-                profile={profile}
-                moderationOpts={moderationOpts}
-              />
-              <ProfileCard.Description profile={profile} />
-            </ProfileCard.Outer>
-          </ProfileCard.Link>
-        ))}
+                <ProfileCard.Description profile={profile} />
+              </ProfileCard.Outer>
+            </ProfileCard.Link>
+          ))}
+        </View>
+        {/* The preview fades into the page rather than ending on a hard cut,
+         * signaling the roster continues. */}
+        {canToggle && !expanded && (
+          <LinearGradient
+            key={t.name} // android does not update when you change the colors. sigh.
+            start={[0.5, 0]}
+            end={[0.5, 1]}
+            colors={[
+              transparentifyColor(t.atoms.bg.backgroundColor, 0),
+              t.atoms.bg.backgroundColor,
+            ]}
+            style={[a.absolute, a.inset_0, {top: 'auto', height: 96}]}
+            pointerEvents="none"
+          />
+        )}
       </View>
+      {canToggle && (
+        <View style={[a.px_lg, a.pt_sm]}>
+          <Button
+            label={
+              expanded
+                ? l`Show fewer reporters`
+                : l`Show all ${i18n.number(profiles.length)} reporters`
+            }
+            onPress={() => setExpanded(v => !v)}
+            size="small"
+            variant="ghost"
+            color="secondary"
+            style={[a.w_full, a.justify_center]}>
+            <ButtonText>
+              {expanded ? (
+                <Trans>Show fewer</Trans>
+              ) : (
+                <Trans>Show all {i18n.number(profiles.length)} reporters</Trans>
+              )}
+            </ButtonText>
+          </Button>
+        </View>
+      )}
     </View>
   )
 }
@@ -141,9 +257,60 @@ function useReporterProfiles(dids: string[]) {
   }
 }
 
-function NewsModule() {
+function NewsModule({
+  compact = false,
+}: {
+  /** One tappable row for the inline rail; see the rail's prop. */
+  compact?: boolean
+}) {
   const t = useTheme()
   const {t: l} = useLingui()
+
+  if (compact) {
+    return (
+      <View style={[a.px_lg, a.pb_xl]}>
+        <Link
+          to="/news"
+          label={l`Open your news feed`}
+          style={[a.w_full, a.rounded_md]}>
+          {({hovered, pressed}) => (
+            <View
+              style={[
+                a.w_full,
+                a.flex_row,
+                a.align_center,
+                a.gap_sm,
+                a.p_md,
+                a.rounded_md,
+                a.transition_color,
+                {
+                  backgroundColor:
+                    hovered || pressed
+                      ? t.palette.primary_100
+                      : t.palette.primary_50,
+                },
+              ]}>
+              <NewspaperIcon size="md" style={{color: t.palette.primary_600}} />
+              <Text
+                style={[
+                  a.flex_1,
+                  a.text_md,
+                  a.font_bold,
+                  {color: t.palette.primary_600},
+                ]}>
+                <Trans>Your News</Trans>
+              </Text>
+              <ChevronRightIcon
+                size="sm"
+                style={{color: t.palette.primary_500}}
+              />
+            </View>
+          )}
+        </Link>
+      </View>
+    )
+  }
+
   return (
     <View style={[a.pb_xl]}>
       <ModuleHeader.Container>

--- a/src/features/newsrooms/components/NewsroomRightRail.tsx
+++ b/src/features/newsrooms/components/NewsroomRightRail.tsx
@@ -27,6 +27,7 @@ import {Link} from '#/components/Link'
 import * as ProfileCard from '#/components/ProfileCard'
 import {Text} from '#/components/Typography'
 import {ExploreLiveSportsWidget} from '#/features/liveSports/components/ExploreLiveSportsWidget'
+import {readableAccent} from '../accent'
 import {
   getDefaultNewsroomPublisher,
   getNewsroomPublisherByDid,
@@ -108,7 +109,7 @@ function ReportersModule({
   const shown =
     canToggle && !expanded ? profiles.slice(0, COLLAPSED_SHOWN) : profiles
 
-  const accent = publisher.accent ?? t.palette.primary_500
+  const accent = readableAccent(publisher.accent, t)
 
   const header = (
     <ModuleHeader.Container
@@ -129,9 +130,9 @@ function ReportersModule({
             {i18n.number(profiles.length)}
           </Text>
           {expanded ? (
-            <ChevronUpIcon size="sm" style={t.atoms.text_contrast_low} />
+            <ChevronUpIcon size="sm" style={t.atoms.text_contrast_medium} />
           ) : (
-            <ChevronDownIcon size="sm" style={t.atoms.text_contrast_low} />
+            <ChevronDownIcon size="sm" style={t.atoms.text_contrast_medium} />
           )}
         </>
       )}

--- a/src/features/newsrooms/components/NewsroomSwitcher.tsx
+++ b/src/features/newsrooms/components/NewsroomSwitcher.tsx
@@ -7,6 +7,7 @@ import {UserAvatar} from '#/view/com/util/UserAvatar'
 import {atoms as a, useTheme} from '#/alf'
 import {Button} from '#/components/Button'
 import {Text} from '#/components/Typography'
+import {readableAccent} from '../accent'
 import {getPublisherName, type NewsroomPublisher} from '../publishers'
 
 /**
@@ -66,7 +67,7 @@ function OrgTab({
 }) {
   const t = useTheme()
   const {t: l} = useLingui()
-  const accent = publisher.accent ?? t.palette.primary_500
+  const accent = readableAccent(publisher.accent, t)
   const name = getPublisherName(profile)
 
   return (

--- a/src/features/newsrooms/discussion.ts
+++ b/src/features/newsrooms/discussion.ts
@@ -1,23 +1,9 @@
-import {type AppBskyFeedDefs} from '@atproto/api'
-
-import {postUriToRelativePath} from '#/lib/strings/url-helpers'
-
 /**
- * Where an article's in-network posts live. The publisher's own post is the
- * article's canonical thread, so it wins; without one, a URL search is the only
- * view that gathers every post about the article.
+ * Where an article's Atmosphere mentions live: a URL search gathers every post
+ * that features the piece, whoever posted it. The publisher's canonical post
+ * (`anchor`) is reached separately - "Open the thread" links into it, and it
+ * seeds the composer via "Join the conversation" and quote-shares.
  */
-export function articleDiscussionPath({
-  url,
-  anchor,
-}: {
-  url: string
-  anchor?: AppBskyFeedDefs.PostView | null
-}): {path: string; isAnchor: boolean} {
-  const anchorPath = anchor
-    ? postUriToRelativePath(anchor.uri, {handle: anchor.author.handle})
-    : undefined
-  return anchorPath
-    ? {path: anchorPath, isAnchor: true}
-    : {path: `/search?q=${encodeURIComponent(url)}`, isAnchor: false}
+export function articleSearchPath(url: string): string {
+  return `/search?q=${encodeURIComponent(url)}`
 }

--- a/src/features/newsrooms/publishers.ts
+++ b/src/features/newsrooms/publishers.ts
@@ -23,6 +23,12 @@ export interface NewsroomPublisher {
   did: string
   /** Per-publisher brand accent, tinting the follow button and share CTA. */
   accent?: string
+  /**
+   * Hostnames the publisher's site lives on. A post anywhere in the app that
+   * links to one of these (subdomains included) gets a chip pointing back to
+   * the publisher's newsroom.
+   */
+  domains: string[]
   /** Category filter chips, e.g. Politics, World, Economy, Culture. */
   categories: string[]
   /** Accounts surfaced in the "Reporters" rail / merged feed. */
@@ -34,6 +40,7 @@ export interface NewsroomPublisher {
 export const NEWSROOM_PUBLISHERS: NewsroomPublisher[] = [
   {
     id: 'financial-times',
+    domains: ['ft.com', 'ft.trib.al'],
     did: 'did:plc:5u54z2qgkq43dh2nzwzdbbhb',
     // FT claret; the avatar salmon is too light for a button.
     accent: '#990F3D',
@@ -60,6 +67,7 @@ export const NEWSROOM_PUBLISHERS: NewsroomPublisher[] = [
   },
   {
     id: 'the-verge',
+    domains: ['theverge.com'],
     did: 'did:plc:7exlcsle4mjfhu3wnhcgizz6',
     accent: '#5200FD',
     categories: ['Tech', 'Science', 'Culture'],
@@ -81,6 +89,7 @@ export const NEWSROOM_PUBLISHERS: NewsroomPublisher[] = [
   },
   {
     id: 'wired',
+    domains: ['wired.com'],
     did: 'did:plc:inz4fkbbp7ms3ixufw6xuvdi',
     categories: ['Tech', 'Security', 'Science', 'Culture'],
     reporterDids: [
@@ -100,6 +109,7 @@ export const NEWSROOM_PUBLISHERS: NewsroomPublisher[] = [
   },
   {
     id: 'new-york-times',
+    domains: ['nytimes.com', 'nyti.ms'],
     did: 'did:plc:eclio37ymobqex2ncko63h4r',
     categories: ['World', 'Politics', 'Business', 'Culture'],
     reporterDids: [
@@ -132,6 +142,7 @@ export const NEWSROOM_PUBLISHERS: NewsroomPublisher[] = [
   },
   {
     id: 'euractiv',
+    domains: ['euractiv.com'],
     did: 'did:plc:npdxsw4zvih4gcyqppoql7qk',
     accent: '#637D8A',
     categories: ['EU', 'Politics', 'Policy'],
@@ -154,6 +165,7 @@ export const NEWSROOM_PUBLISHERS: NewsroomPublisher[] = [
   },
   {
     id: '404-media',
+    domains: ['404media.co'],
     did: 'did:plc:vcepp6trx4vpe5ourxso4tjl',
     accent: '#16A34A',
     categories: ['Technology', 'Privacy', 'Policy'],
@@ -167,6 +179,7 @@ export const NEWSROOM_PUBLISHERS: NewsroomPublisher[] = [
   },
   {
     id: 'cnn',
+    domains: ['cnn.com', 'cnn.it'],
     did: 'did:plc:dzezcmpb3fhcpns4n4xm4ur5',
     accent: '#CD0001',
     categories: ['World', 'Politics', 'US'],
@@ -190,6 +203,7 @@ export const NEWSROOM_PUBLISHERS: NewsroomPublisher[] = [
   },
   {
     id: 'nrc',
+    domains: ['nrc.nl'],
     did: 'did:plc:bvkk4kkuavnhqrwapc34wtfp',
     accent: '#D40811',
     categories: ['Netherlands', 'World', 'Politics'],
@@ -200,6 +214,7 @@ export const NEWSROOM_PUBLISHERS: NewsroomPublisher[] = [
   },
   {
     id: 'propublica',
+    domains: ['propublica.org', 'propub.li'],
     did: 'did:plc:k4jt6heuiamymgi46yeuxtpt',
     categories: ['Investigations', 'Politics', 'Justice'],
     reporterDids: [
@@ -221,6 +236,7 @@ export const NEWSROOM_PUBLISHERS: NewsroomPublisher[] = [
   },
   {
     id: 'euobserver',
+    domains: ['euobserver.com', 'euobs.com'],
     did: 'did:plc:xnmkjaouspdzqv4hzvvcf3j3',
     accent: '#EF513B',
     categories: ['EU', 'Politics', 'Green Economy', 'Migration', 'Digital'],
@@ -233,6 +249,7 @@ export const NEWSROOM_PUBLISHERS: NewsroomPublisher[] = [
   },
   {
     id: 'the-guardian',
+    domains: ['theguardian.com', 'gu.com'],
     did: 'did:plc:vovinwhtulbsx4mwfw26r5ni',
     accent: '#052962',
     categories: ['Europe', 'World', 'Politics', 'Culture'],
@@ -252,6 +269,7 @@ export const NEWSROOM_PUBLISHERS: NewsroomPublisher[] = [
   },
   {
     id: 'le-monde',
+    domains: ['lemonde.fr', 'lemde.fr'],
     did: 'did:plc:qqxqxgdu5z3he2piqfbfaku4',
     categories: ['France', 'World', 'Politics'],
     reporterDids: [
@@ -300,6 +318,7 @@ export const NEWSROOM_PUBLISHERS: NewsroomPublisher[] = [
   },
   {
     id: 'el-pais',
+    domains: ['elpais.com'],
     did: 'did:plc:u6mkbcgviwlbhuwqirmhcgu3',
     accent: '#0067A0',
     categories: ['Spain', 'World', 'Politics'],
@@ -324,6 +343,7 @@ export const NEWSROOM_PUBLISHERS: NewsroomPublisher[] = [
   },
   {
     id: 'next',
+    domains: ['next.ink'],
     did: 'did:plc:o4gygiehiqr7hcpyicprn6w4',
     accent: '#4A5CFE',
     categories: ['Tech', 'Digital Policy', 'Privacy'],
@@ -344,6 +364,27 @@ export function getNewsroomPublisherByDid(
   did: string,
 ): NewsroomPublisher | undefined {
   return NEWSROOM_PUBLISHERS.find(p => p.did === did)
+}
+
+/**
+ * The publisher whose site a URL points at, if any. Matches the hostname
+ * against each publisher's registered `domains`, subdomains included, so
+ * `www.ft.com` and `rss.nytimes.com` resolve to their orgs.
+ */
+export function getNewsroomPublisherByUrl(
+  url: string,
+): NewsroomPublisher | undefined {
+  let hostname: string
+  try {
+    hostname = new URL(url).hostname.toLowerCase()
+  } catch {
+    return undefined
+  }
+  return NEWSROOM_PUBLISHERS.find(p =>
+    p.domains.some(
+      domain => hostname === domain || hostname.endsWith('.' + domain),
+    ),
+  )
 }
 
 /**

--- a/src/features/newsrooms/queries.ts
+++ b/src/features/newsrooms/queries.ts
@@ -3,7 +3,7 @@ import {
   type AppBskyFeedDefs,
   type AppBskyFeedPost,
 } from '@atproto/api'
-import {useQuery} from '@tanstack/react-query'
+import {useQueries, useQuery} from '@tanstack/react-query'
 
 import {STALE} from '#/state/queries'
 import {createQueryKey} from '#/state/queries/util'
@@ -69,33 +69,22 @@ export const createArticleDiscussionQueryKey = (args: {
 }) => createQueryKey('newsroomArticleDiscussion', args)
 
 /**
- * The in-network conversation about a specific article: posts across the network
- * that link to its URL. This is the page's reason to exist - the discussion the
- * publisher's own site and the scattered home feed don't put next to the piece.
- *
- * `searchPosts` indexes link facets, so a URL query surfaces posts that shared
- * it; we then keep only posts that genuinely reference the URL (rather than
- * merely matching its tokens) and rank by engagement.
- *
- * When the publisher itself posted the article, that post is the article's
- * canonical thread: it is pinned first and returned as `anchor`, so sharing can
- * quote it (growing one conversation) instead of starting a parallel one.
+ * Shared query definition for an article's discussion, so the single-article
+ * hook and the front page's all-articles lookup hit one cache entry per URL.
  */
-export function useArticleDiscussionQuery({
+function articleDiscussionQueryOptions({
   url,
   publisherDid,
-  enabled = true,
+  agent,
 }: {
   url: string
   publisherDid?: string
-  enabled?: boolean
+  agent: ReturnType<typeof useAgent>
 }) {
-  const agent = useAgent()
-
-  return useQuery({
+  return {
     queryKey: createArticleDiscussionQueryKey({url, publisherDid}),
     staleTime: STALE.MINUTES.FIVE,
-    enabled: enabled && !!url,
+    enabled: !!url,
     queryFn: async () => {
       const res = await agent.app.bsky.feed.searchPosts({
         q: url,
@@ -131,13 +120,87 @@ export function useArticleDiscussionQuery({
         }
       }
 
-      const ordered = anchor
-        ? [anchor, ...posts.filter(post => post.uri !== anchor.uri)]
+      /*
+       * The publisher's own post wins the top slot - it is the article's
+       * canonical thread - and the rest of the conversation ranks by its
+       * interactions in the Atmosphere.
+       */
+      const rest = anchor
+        ? posts.filter(post => post.uri !== anchor.uri)
         : posts
+      const orderedRest = [...rest].sort(
+        (a, b) => engagementScore(b) - engagementScore(a),
+      )
+      const ordered = anchor ? [anchor, ...orderedRest] : orderedRest
       const total = Math.max(res.data.hitsTotal ?? posts.length, ordered.length)
-      return {posts: ordered, total, anchor}
+      /* The article's pull in the Atmosphere; picks the front page's featured
+       * story. */
+      const interactions = ordered.reduce(
+        (sum, post) => sum + engagementScore(post),
+        0,
+      )
+      return {posts: ordered, total, anchor, interactions}
     },
+  }
+}
+
+/**
+ * The in-network conversation about a specific article: posts across the network
+ * that link to its URL. This is the page's reason to exist - the discussion the
+ * publisher's own site and the scattered home feed don't put next to the piece.
+ *
+ * `searchPosts` indexes link facets, so a URL query surfaces posts that shared
+ * it; we then keep only posts that genuinely reference the URL (rather than
+ * merely matching its tokens).
+ *
+ * When the publisher itself posted the article, that post is the article's
+ * canonical thread: it is pinned first and returned as `anchor`, so sharing can
+ * quote it (growing one conversation) instead of starting a parallel one. The
+ * remaining posts rank by their Atmosphere interactions (likes, reposts,
+ * replies, quotes).
+ */
+export function useArticleDiscussionQuery({
+  url,
+  publisherDid,
+  enabled = true,
+}: {
+  url: string
+  publisherDid?: string
+  enabled?: boolean
+}) {
+  const agent = useAgent()
+  const options = articleDiscussionQueryOptions({url, publisherDid, agent})
+  return useQuery({...options, enabled: enabled && options.enabled})
+}
+
+/**
+ * The discussions for a whole front page of articles at once, one cache-shared
+ * query per URL. The front page uses the per-article `interactions` totals to
+ * feature the story the Atmosphere engaged with most.
+ */
+export function useArticleDiscussionsQuery({
+  urls,
+  publisherDid,
+}: {
+  urls: string[]
+  publisherDid?: string
+}) {
+  const agent = useAgent()
+  return useQueries({
+    queries: urls.map(url =>
+      articleDiscussionQueryOptions({url, publisherDid, agent}),
+    ),
   })
+}
+
+/** A post's total interactions in the Atmosphere; ranks the discussion. */
+function engagementScore(post: AppBskyFeedDefs.PostView): number {
+  return (
+    (post.likeCount ?? 0) +
+    (post.repostCount ?? 0) +
+    (post.replyCount ?? 0) +
+    (post.quoteCount ?? 0)
+  )
 }
 
 /** Whether a post links to `url`, comparing normalized host + path. */

--- a/src/features/newsrooms/text.ts
+++ b/src/features/newsrooms/text.ts
@@ -1,0 +1,9 @@
+/**
+ * Flattens multi-line user text into one paragraph for clamped previews
+ * (publisher bio, discussion post snippets). Hard line breaks inside a
+ * `numberOfLines` clamp can leave the truncation ellipsis stranded alone on
+ * an otherwise-empty line; collapsing whitespace keeps it glued to the text.
+ */
+export function toSingleParagraph(text: string): string {
+  return text.replace(/\s+/g, ' ').trim()
+}


### PR DESCRIPTION
Deeper newsroom integration across the app, plus a rework of how the front page picks its featured content.

Added newsroom discovery links to posts with links to the publisher's website. 

Featured story in newsroom is now the story with the most interactions from the atmosphere, weighted toward the last day or so.

"Join the conversation" now opens the composer, and if there's a thread from the publisher, a "Open the thread" option will show directing to the publisher's post. 

The discussion block's header and the "# posts" counts now open a search of all posts featuring the article

Some layout changes. 

Newsroom now links back to the news feed page from the header, mirroring the news feed header. 

Reporters section collapses to a short preview on mobile.

Bigger section headings with publisher accent colors. 