### PR TITLE
Link web application manifest in HTML

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -20,6 +20,8 @@
     <link rel="preconnect" href="https://go.bsky.app">
     <title>%WEB_TITLE%</title>
 
+    <link rel="manifest" href="manifest.json" />
+
     <!--
       mu fork: DEFAULT (fallback) Open Graph / Twitter card metadata for link
       unfurls. This is a static SPA (no per-route SSR), so this default card is


### PR DESCRIPTION
Linking the web application manifest in the HTML is one requirement to make mu.social work as a PWA in Firefox mobile on Android.

There is one more requirement that needs to be resolved by the Eurosky devs, because the manifest is not in the repo and I haven't figured out how to generate additional images with the build pipeline: Provide two large application icons and link them in the manifest.json. See my comment here: https://github.com/eurosky-social/eurosky-social-app/issues/135#issuecomment-5107955392
