### PR TITLE
Marque integration for registering domains and automatically setting the handle

### DIFF
--- a/src/lib/api/marque/index.ts
+++ b/src/lib/api/marque/index.ts
@@ -1,0 +1,491 @@
+/** Marque Partner API and portable repository-record helpers. */
+import {
+  type Client,
+  type DidString,
+  type Service,
+  XrpcResponseError,
+} from '@atproto/lex'
+
+import {
+  checkAvailability as checkAvailabilitySchema,
+  createCheckout as createCheckoutSchema,
+  getOrder as getOrderSchema,
+  getRequirements as getRequirementsSchema,
+  listPricing as listPricingSchema,
+} from './schemas'
+
+export const MARQUE_REGISTRAR: Service = 'did:web:marque.at#marque_registrar'
+
+const proxyToMarque = {service: MARQUE_REGISTRAR} as const
+
+export type TldPricing = {
+  tld: string
+  registerPrice: number
+  renewPrice: number
+  transferPrice: number
+  popular?: boolean
+  transferAddsYear?: boolean
+  whoisPrivacyAllowed?: boolean
+  minPeriod?: number
+  maxPeriod?: number
+}
+
+export type AvailabilityResult = {
+  domain: string
+  available?: boolean
+  status?: string
+  price?: number
+  renewPrice?: number
+  transferPrice?: number
+  premiumPrice?: number
+  isPremium?: boolean
+  transferAddsYear?: boolean
+  minPeriod?: number
+  maxPeriod?: number
+  whoisPrivacyAllowed?: boolean
+  error?: string
+}
+
+export type PaymentMethod = 'stripe' | 'paypal' | 'nowpayments'
+
+export type DomainRequirement = {
+  domain: string
+  passportNumberRequired: boolean
+  companyRegistrationNumberRequired: boolean
+  taxNumberRequired: boolean
+  additionalData: RequirementSpec[]
+  customerAdditionalData: RequirementSpec[]
+}
+
+export type RequirementSpec = {
+  name: string
+  description: string
+  required: boolean
+  type: string
+  pattern?: string
+  syntax?: string
+  options?: {description: string; value: string; requires?: string[]}[]
+}
+
+export type CheckoutItem = {
+  domain: string
+  years?: number
+  whoisPrivacy?: boolean
+  autoRenew?: boolean
+}
+
+export type Registrant = {
+  firstName: string
+  lastName: string
+  email: string
+  phoneCountryCode: string
+  phoneSubscriber: string
+  street: string
+  city: string
+  zipcode: string
+  country: string
+  state?: string
+  organization?: string
+  phoneAreaCode?: string
+  taxIdType?: string
+  taxIdValue?: string
+  companyRegistrationNumber?: string
+  passportNumber?: string
+  socialSecurityNumber?: string
+}
+
+export type CheckoutResponse = {
+  orderId: string
+  checkoutUrl: string
+  subtotalCents: number
+  taxCents?: number
+  totalCents: number
+  currency: string
+  paymentMethod?: string
+}
+
+export type OrderItem = {
+  domain: string
+  status: string
+  registeredAt?: string
+  expiresAt?: string
+  nameServers?: string[]
+  error?: string
+}
+
+export const ORDER_ACTIVE = 'provisioned'
+export const ORDER_FAILED = 'failed'
+export const ITEM_ACTIVE = 'active'
+export const ITEM_FAILED = 'failed'
+
+export type Order = {
+  orderId: string
+  status: string
+  paidAt?: string
+  checkoutUrl?: string
+  error?: string
+  items: OrderItem[]
+}
+
+export type ProvisionedDomain = {
+  domain: string
+  registeredAt?: string
+  expiresAt?: string
+  nameServers: string[]
+}
+
+export type MarqueDomainRecord = {
+  uri: string
+  cid: string
+  domain: string
+  status: string
+  nameServers: string[]
+}
+
+export type MarqueDnsEntry = {
+  name: string
+  recordType: string
+  value: string
+  ttl: number
+  priority?: number
+}
+
+export type MarqueDnsRecord = {
+  uri: string
+  cid: string
+  domain: string
+  subject: {uri: string; cid: string}
+  records: MarqueDnsEntry[]
+}
+
+function isRecordNotFound(error: unknown) {
+  return (
+    error instanceof XrpcResponseError &&
+    (error.error === 'RecordNotFound' || error.status === 404)
+  )
+}
+
+function parseDomainRecord(record: {
+  uri: string
+  cid: string
+  value: Record<string, unknown>
+}): MarqueDomainRecord | null {
+  const {value} = record
+  if (
+    value.$type !== 'at.marque.domain' ||
+    typeof value.domain !== 'string' ||
+    typeof value.status !== 'string'
+  ) {
+    return null
+  }
+  return {
+    uri: record.uri,
+    cid: record.cid,
+    domain: value.domain,
+    status: value.status,
+    nameServers: Array.isArray(value.nameServers)
+      ? value.nameServers.filter((v): v is string => typeof v === 'string')
+      : [],
+  }
+}
+
+function parseDnsRecord(record: {
+  uri: string
+  cid: string
+  value: Record<string, unknown>
+}): MarqueDnsRecord | null {
+  const {value} = record
+  if (
+    value.$type !== 'at.marque.dns' ||
+    typeof value.domain !== 'string' ||
+    !value.subject ||
+    typeof value.subject !== 'object' ||
+    !('uri' in value.subject) ||
+    !('cid' in value.subject) ||
+    typeof value.subject.uri !== 'string' ||
+    typeof value.subject.cid !== 'string'
+  ) {
+    return null
+  }
+  const records: MarqueDnsEntry[] = []
+  const rawRecords: unknown[] = Array.isArray(value.records)
+    ? value.records
+    : []
+  for (const item of rawRecords) {
+    if (
+      item &&
+      typeof item === 'object' &&
+      'name' in item &&
+      'recordType' in item &&
+      'value' in item &&
+      'ttl' in item &&
+      typeof item.name === 'string' &&
+      typeof item.recordType === 'string' &&
+      typeof item.value === 'string' &&
+      typeof item.ttl === 'number'
+    ) {
+      records.push({
+        name: item.name,
+        recordType: item.recordType,
+        value: item.value,
+        ttl: item.ttl,
+        priority:
+          'priority' in item && typeof item.priority === 'number'
+            ? item.priority
+            : undefined,
+      })
+    }
+  }
+  return {
+    uri: record.uri,
+    cid: record.cid,
+    domain: value.domain,
+    subject: {uri: value.subject.uri, cid: value.subject.cid},
+    records,
+  }
+}
+
+/** Read one Marque-owned domain record by its FQDN record key. */
+export async function getMarqueDomainRecord(
+  client: Client,
+  did: DidString,
+  domain: string,
+): Promise<MarqueDomainRecord | null> {
+  try {
+    const res = await client.getRecord('at.marque.domain', domain, {repo: did})
+    if (!res.body.cid) return null
+    return parseDomainRecord({
+      uri: res.body.uri,
+      cid: res.body.cid,
+      value: res.body.value,
+    })
+  } catch (error) {
+    if (isRecordNotFound(error)) return null
+    throw error
+  }
+}
+
+/** Read one Marque DNS zone record by the matching domain record key. */
+export async function getMarqueDnsRecord(
+  client: Client,
+  did: DidString,
+  domain: string,
+): Promise<MarqueDnsRecord | null> {
+  try {
+    const res = await client.getRecord('at.marque.dns', domain, {
+      repo: did,
+    })
+    if (!res.body.cid) return null
+    return parseDnsRecord({
+      uri: res.body.uri,
+      cid: res.body.cid,
+      value: res.body.value,
+    })
+  } catch (error) {
+    if (isRecordNotFound(error)) return null
+    throw error
+  }
+}
+
+/** Find the longest active Marque-owned domain that contains this handle. */
+export async function findMarqueDomainForHandle(
+  client: Client,
+  did: DidString,
+  handle: string,
+): Promise<MarqueDomainRecord | null> {
+  const normalized = handle.toLowerCase().replace(/^@/, '')
+  const domains = await listMarqueDomainRecords(client, did)
+  const matches = domains.filter(
+    domain =>
+      domain.status === 'active' &&
+      (normalized === domain.domain ||
+        normalized.endsWith(`.${domain.domain}`)),
+  )
+  return matches.sort((a, b) => b.domain.length - a.domain.length)[0] ?? null
+}
+
+/** List every valid Marque domain record in the user's repository. */
+export async function listMarqueDomainRecords(
+  client: Client,
+  did: DidString,
+): Promise<MarqueDomainRecord[]> {
+  let cursor: string | undefined
+  const domains: MarqueDomainRecord[] = []
+  do {
+    const res = await client.listRecords('at.marque.domain', {
+      repo: did,
+      limit: 100,
+      cursor,
+    })
+    for (const item of res.body.records) {
+      const parsed = parseDomainRecord({
+        uri: item.uri,
+        cid: item.cid,
+        value: item.value,
+      })
+      if (parsed) domains.push(parsed)
+    }
+    cursor = res.body.cursor
+  } while (cursor)
+  return domains
+}
+
+/**
+ * Add the missing AT Protocol TXT record to a Marque-managed DNS zone.
+ * Existing records are preserved. A conflicting existing TXT record is left
+ * untouched so the client never silently overwrites another DID delegation.
+ */
+export async function ensureMarqueAtprotoRecord(
+  client: Client,
+  did: DidString,
+  handle: string,
+): Promise<'created' | 'exists' | 'conflict' | 'not-owned'> {
+  const normalized = handle.toLowerCase().replace(/^@/, '')
+  const domain = await findMarqueDomainForHandle(client, did, normalized)
+  if (!domain) return 'not-owned'
+
+  const relative =
+    normalized === domain.domain
+      ? ''
+      : normalized.slice(0, -`.${domain.domain}`.length)
+  const name = relative ? `_atproto.${relative}` : '_atproto'
+  const value = `did=${did}`
+  const dns = await getMarqueDnsRecord(client, did, domain.domain)
+  const records = dns?.records ?? []
+  const existing = records.find(
+    record => record.name === name && record.recordType.toUpperCase() === 'TXT',
+  )
+  if (existing?.value === value) return 'exists'
+  if (existing) return 'conflict'
+
+  await putDnsRecord(
+    client,
+    did,
+    domain.domain,
+    {
+      uri: domain.uri,
+      cid: domain.cid,
+    },
+    [...records, {name, recordType: 'TXT', value, ttl: 300}],
+  )
+  return 'created'
+}
+
+/**
+ * `at.marque.partner.listPricing` — list offered TLDs and standard pricing.
+ */
+export async function listPricing(
+  client: Client,
+): Promise<{tlds: TldPricing[]}> {
+  return client.call(listPricingSchema, {}, proxyToMarque)
+}
+
+/**
+ * `at.marque.partner.checkAvailability` — check 1-500 candidate domains with
+ * live (possibly premium) pricing. Each result is independent; a row-level
+ * failure surfaces in that row's `error` field rather than throwing.
+ */
+export async function checkAvailability(
+  client: Client,
+  domains: string[],
+): Promise<{results: AvailabilityResult[]}> {
+  return client.call(checkAvailabilitySchema, {domains}, proxyToMarque)
+}
+
+/** Registry-specific fields that must be collected before checkout. */
+export async function getRequirements(
+  client: Client,
+  domains: string[],
+): Promise<{results: DomainRequirement[]}> {
+  return client.call(getRequirementsSchema, {domains}, proxyToMarque)
+}
+
+/**
+ * `at.marque.partner.createCheckout` — validate an order and create a hosted
+ * payment page. Redirect the user to the returned `checkoutUrl`.
+ */
+export async function createCheckout(
+  client: Client,
+  input: {
+    items: CheckoutItem[]
+    registrant: Registrant
+    paymentMethod?: PaymentMethod
+    successUrl: string
+    cancelUrl: string
+  },
+): Promise<CheckoutResponse> {
+  return client.call(createCheckoutSchema, input, proxyToMarque)
+}
+
+/**
+ * `at.marque.partner.getOrder` — poll payment and provisioning status. Poll
+ * until `provisioned` or `failed`, then inspect each item individually.
+ */
+export async function getOrder(
+  client: Client,
+  orderId: string,
+): Promise<Order> {
+  return client.call(getOrderSchema, {orderId}, proxyToMarque)
+}
+
+/**
+ * Write the `at.marque.domain` record to the user's repository, keyed by the
+ * fully qualified domain. Returns the AT URI and CID needed for the DNS
+ * record's strong reference.
+ */
+export async function putDomainRecord(
+  client: Client,
+  did: DidString,
+  domain: string,
+  value: {
+    status: string
+    registeredAt?: string
+    expiresAt?: string
+    nameServers?: string[]
+    autoRenew?: boolean
+  },
+): Promise<{uri: string; cid: string}> {
+  const now = new Date().toISOString()
+  const res = await client.putRecord(
+    {
+      $type: 'at.marque.domain',
+      domain,
+      status: value.status,
+      registeredAt: value.registeredAt,
+      expiresAt: value.expiresAt,
+      nameServers: value.nameServers,
+      autoRenew: value.autoRenew,
+      createdAt: now,
+    },
+    domain,
+    {repo: did, validate: false},
+  )
+  return {uri: res.body.uri, cid: res.body.cid}
+}
+
+/**
+ * Write the `at.marque.dns` record, pointing back at the matching
+ * `at.marque.domain` record. Only meaningful when the domain uses Marque
+ * nameservers.
+ */
+export async function putDnsRecord(
+  client: Client,
+  did: DidString,
+  domain: string,
+  subject: {uri: string; cid: string},
+  records: MarqueDnsEntry[] = [],
+): Promise<{uri: string; cid: string}> {
+  const now = new Date().toISOString()
+  const res = await client.putRecord(
+    {
+      $type: 'at.marque.dns',
+      domain,
+      subject,
+      records,
+      createdAt: now,
+    },
+    domain,
+    {repo: did, validate: false},
+  )
+  return {uri: res.body.uri, cid: res.body.cid}
+}

--- a/src/lib/api/marque/schemas.ts
+++ b/src/lib/api/marque/schemas.ts
@@ -1,0 +1,199 @@
+/** Runtime schemas for Marque's third-party partner lexicons. */
+import {l} from '@atproto/lex'
+
+const listPricingNsid = 'at.marque.partner.listPricing'
+
+export const listPricingParams = l.params()
+
+export const listPricingOutput = l.jsonPayload({
+  tlds: l.array(
+    l.object({
+      tld: l.string(),
+      registerPrice: l.integer(),
+      renewPrice: l.integer(),
+      transferPrice: l.integer(),
+      popular: l.optional(l.boolean()),
+      transferAddsYear: l.optional(l.boolean()),
+      whoisPrivacyAllowed: l.optional(l.boolean()),
+      minPeriod: l.optional(l.integer()),
+      maxPeriod: l.optional(l.integer()),
+    }),
+  ),
+})
+
+/** List offered TLDs and standard pricing. */
+export const listPricing = l.query(
+  listPricingNsid,
+  listPricingParams,
+  listPricingOutput,
+)
+
+const checkAvailabilityNsid = 'at.marque.partner.checkAvailability'
+
+export const checkAvailabilityParams = l.params({
+  domains: l.array(l.string(), {minLength: 1, maxLength: 500}),
+})
+
+export const checkAvailabilityOutput = l.jsonPayload({
+  results: l.array(
+    l.object({
+      domain: l.string(),
+      available: l.optional(l.boolean()),
+      status: l.optional(
+        l.string({knownValues: ['free', 'premium', 'active']}),
+      ),
+      price: l.optional(l.integer()),
+      renewPrice: l.optional(l.integer()),
+      transferPrice: l.optional(l.integer()),
+      premiumPrice: l.optional(l.integer()),
+      isPremium: l.optional(l.boolean()),
+      transferAddsYear: l.optional(l.boolean()),
+      minPeriod: l.optional(l.integer()),
+      maxPeriod: l.optional(l.integer()),
+      whoisPrivacyAllowed: l.optional(l.boolean()),
+      error: l.optional(l.string()),
+    }),
+  ),
+})
+
+/** Check up to 500 domains with live premium pricing. */
+export const checkAvailability = l.query(
+  checkAvailabilityNsid,
+  checkAvailabilityParams,
+  checkAvailabilityOutput,
+)
+
+const requirementSpec = l.object({
+  name: l.string(),
+  description: l.string(),
+  required: l.boolean(),
+  type: l.string(),
+  pattern: l.optional(l.string()),
+  syntax: l.optional(l.string()),
+  options: l.optional(
+    l.array(
+      l.object({
+        description: l.string(),
+        value: l.string(),
+        requires: l.optional(l.array(l.string())),
+      }),
+    ),
+  ),
+})
+
+export const getRequirements = l.query(
+  'at.marque.partner.getRequirements',
+  l.params({domains: l.array(l.string(), {minLength: 1, maxLength: 50})}),
+  l.jsonPayload({
+    results: l.array(
+      l.object({
+        domain: l.string(),
+        passportNumberRequired: l.boolean(),
+        companyRegistrationNumberRequired: l.boolean(),
+        taxNumberRequired: l.boolean(),
+        additionalData: l.array(requirementSpec),
+        customerAdditionalData: l.array(requirementSpec),
+      }),
+    ),
+  }),
+)
+
+const createCheckoutNsid = 'at.marque.partner.createCheckout'
+
+export const createCheckoutInput = l.jsonPayload({
+  items: l.array(
+    l.object({
+      domain: l.string(),
+      years: l.optional(l.integer()),
+      whoisPrivacy: l.optional(l.boolean()),
+      autoRenew: l.optional(l.boolean()),
+    }),
+    {minLength: 1, maxLength: 50},
+  ),
+  registrant: l.object({
+    firstName: l.string(),
+    lastName: l.string(),
+    email: l.string(),
+    phoneCountryCode: l.string(),
+    phoneSubscriber: l.string(),
+    street: l.string(),
+    city: l.string(),
+    zipcode: l.string(),
+    country: l.string(),
+    state: l.optional(l.string()),
+    organization: l.optional(l.string()),
+    phoneAreaCode: l.optional(l.string()),
+    taxIdType: l.optional(l.string()),
+    taxIdValue: l.optional(l.string()),
+    companyRegistrationNumber: l.optional(l.string()),
+    passportNumber: l.optional(l.string()),
+    socialSecurityNumber: l.optional(l.string()),
+  }),
+  paymentMethod: l.optional(
+    l.string({knownValues: ['stripe', 'paypal', 'nowpayments']}),
+  ),
+  successUrl: l.string(),
+  cancelUrl: l.string(),
+})
+
+export const createCheckoutOutput = l.jsonPayload({
+  orderId: l.string(),
+  checkoutUrl: l.string(),
+  subtotalCents: l.integer(),
+  taxCents: l.optional(l.integer()),
+  totalCents: l.integer(),
+  currency: l.string(),
+  paymentMethod: l.optional(l.string()),
+})
+
+/** Validate an order and create a hosted payment checkout. */
+export const createCheckout = l.procedure(
+  createCheckoutNsid,
+  l.params(),
+  createCheckoutInput,
+  createCheckoutOutput,
+  [
+    'Unavailable',
+    'InvalidRegistrant',
+    'InvalidCallback',
+    'InvalidPaymentMethod',
+    'PaymentAmountTooLow',
+    'PaymentProviderError',
+  ],
+)
+
+const getOrderNsid = 'at.marque.partner.getOrder'
+
+export const getOrderParams = l.params({
+  orderId: l.string(),
+})
+
+export const getOrderOutput = l.jsonPayload({
+  orderId: l.string(),
+  status: l.string({
+    knownValues: [
+      'awaitingPayment',
+      'processing',
+      'paid',
+      'provisioning',
+      'provisioned',
+      'failed',
+    ],
+  }),
+  paidAt: l.optional(l.string({format: 'datetime'})),
+  checkoutUrl: l.optional(l.string({format: 'uri'})),
+  error: l.optional(l.string()),
+  items: l.array(
+    l.object({
+      domain: l.string(),
+      status: l.string({knownValues: ['active', 'failed']}),
+      registeredAt: l.optional(l.string({format: 'datetime'})),
+      expiresAt: l.optional(l.string({format: 'datetime'})),
+      nameServers: l.optional(l.array(l.string())),
+      error: l.optional(l.string()),
+    }),
+  ),
+})
+
+/** Poll payment and provisioning status. */
+export const getOrder = l.query(getOrderNsid, getOrderParams, getOrderOutput)

--- a/src/screens/Settings/AccountSettings.tsx
+++ b/src/screens/Settings/AccountSettings.tsx
@@ -1,8 +1,10 @@
-import {useEffect} from 'react'
+import {useEffect, useRef} from 'react'
 import {Trans, useLingui} from '@lingui/react/macro'
 import {type NativeStackScreenProps} from '@react-navigation/native-stack'
 
+import {useOpenLink} from '#/lib/hooks/useOpenLink'
 import {type CommonNavigatorParams} from '#/lib/routes/types'
+import {useMarqueManagedDomainQuery} from '#/state/queries/marque'
 import {useProfileQuery} from '#/state/queries/profile'
 import {useSession} from '#/state/session'
 import {consumePendingHandleStepUp} from '#/state/session/oauth-web-client'
@@ -22,12 +24,14 @@ import {Bot_Stroke as RobotIcon} from '#/components/icons/Bot'
 import {Car_Stroke2_Corner2_Rounded as CarIcon} from '#/components/icons/Car'
 import {Envelope_Stroke2_Corner2_Rounded as EnvelopeIcon} from '#/components/icons/Envelope'
 import {Freeze_Stroke2_Corner2_Rounded as FreezeIcon} from '#/components/icons/Freeze'
+import {Globe_Stroke2_Corner0_Rounded as GlobeIcon} from '#/components/icons/Globe'
 import {Lock_Stroke2_Corner2_Rounded as LockIcon} from '#/components/icons/Lock'
 import {PencilLine_Stroke2_Corner2_Rounded as PencilIcon} from '#/components/icons/Pencil'
 import {ShieldCheck_Stroke2_Corner0_Rounded as ShieldIcon} from '#/components/icons/Shield'
 import {Trash_Stroke2_Corner2_Rounded} from '#/components/icons/Trash'
 import * as Layout from '#/components/Layout'
 import * as toast from '#/components/Toast'
+import {hasPendingDomainCheckout} from './components/BuyDomainDialog'
 import {ChangeHandleDialog} from './components/ChangeHandleDialog'
 import {ChangePasswordDialog} from './components/ChangePasswordDialog'
 import {DeactivateAccountDialog} from './components/DeactivateAccountDialog'
@@ -35,11 +39,15 @@ import {DeleteAccountDialog} from './components/DeleteAccountDialog'
 import {ExportCarDialog} from './components/ExportCarDialog'
 
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'AccountSettings'>
-export function AccountSettingsScreen({}: Props) {
+export function AccountSettingsScreen({navigation}: Props) {
   const t = useTheme()
   const {t: l} = useLingui()
   const {currentAccount} = useSession()
+  const openLink = useOpenLink()
   const {data: profile} = useProfileQuery({did: currentAccount?.did})
+  const {data: managedDomain} = useMarqueManagedDomainQuery(
+    currentAccount?.handle,
+  )
   const emailDialogControl = useEmailDialogControl()
   const birthdayControl = useDialogControl()
   const changeHandleControl = useDialogControl()
@@ -47,6 +55,7 @@ export function AccountSettingsScreen({}: Props) {
   const exportCarControl = useDialogControl()
   const deactivateAccountControl = useDialogControl()
   const deleteAccountControl = useDialogControl()
+  const didResumeDomainCheckout = useRef(false)
 
   // mu fork: returning from a handle-scope step-up lands here (the callback
   // rewrites the path to /settings/account). Reopen the change-handle dialog so
@@ -61,6 +70,23 @@ export function AccountSettingsScreen({}: Props) {
       })
     }
   }, [changeHandleControl, l])
+
+  // Wait until navigation settles before resuming a hosted checkout.
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const resume = () => {
+      if (!didResumeDomainCheckout.current && hasPendingDomainCheckout()) {
+        didResumeDomainCheckout.current = true
+        timer = setTimeout(() => changeHandleControl.open(), 0)
+      }
+    }
+    const unsubscribe = navigation.addListener('focus', resume)
+    if (navigation.isFocused()) resume()
+    return () => {
+      unsubscribe()
+      if (timer) clearTimeout(timer)
+    }
+  }, [navigation, changeHandleControl])
 
   return (
     <Layout.Screen>
@@ -156,6 +182,25 @@ export function AccountSettingsScreen({}: Props) {
             </SettingsList.ItemText>
             <SettingsList.Chevron />
           </SettingsList.PressableItem>
+          {managedDomain && (
+            <SettingsList.PressableItem
+              label={l`Manage ${managedDomain.domain} in Marque`}
+              accessibilityHint={l`Opens this domain in Marque`}
+              onPress={() =>
+                openLink(
+                  `https://marque.at/dashboard/domains/${encodeURIComponent(managedDomain.domain)}`,
+                )
+              }>
+              <SettingsList.ItemIcon icon={GlobeIcon} />
+              <SettingsList.ItemText>
+                <Trans>Your domain is managed by Marque</Trans>
+              </SettingsList.ItemText>
+              <SettingsList.BadgeText>
+                <Trans>Manage in Marque</Trans>
+              </SettingsList.BadgeText>
+              <SettingsList.Chevron />
+            </SettingsList.PressableItem>
+          )}
           <SettingsList.Item>
             <SettingsList.ItemIcon icon={BirthdayCakeIcon} />
             <SettingsList.ItemText>

--- a/src/screens/Settings/components/BuyDomainDialog.tsx
+++ b/src/screens/Settings/components/BuyDomainDialog.tsx
@@ -1,0 +1,1437 @@
+import {useEffect, useMemo, useRef, useState} from 'react'
+import {ScrollView, type TextInput, View} from 'react-native'
+import Animated, {FadeIn, FadeOut} from 'react-native-reanimated'
+import {Trans, useLingui} from '@lingui/react/macro'
+import {useMutation} from '@tanstack/react-query'
+
+import {
+  type AvailabilityResult,
+  ensureMarqueAtprotoRecord,
+  ITEM_ACTIVE,
+  ORDER_ACTIVE,
+  ORDER_FAILED,
+  type Registrant,
+} from '#/lib/api/marque'
+import {useOpenLink} from '#/lib/hooks/useOpenLink'
+import {cleanError} from '#/lib/strings/errors'
+import {useFetchDid, useUpdateHandleMutation} from '#/state/queries/handle'
+import {
+  useCreateCheckoutMutation,
+  useDomainSearchQuery,
+  useFinalizeDomainPurchaseMutation,
+  useMarquePricingQuery,
+  useMarqueRequirementsQuery,
+  useOrderPollingQuery,
+} from '#/state/queries/marque'
+import {usePdsClient, useSession} from '#/state/session'
+import {oauthUpgradeForHandle} from '#/state/session/oauth-web-client'
+import {atoms as a, useTheme, web} from '#/alf'
+import {Admonition} from '#/components/Admonition'
+import {Button, ButtonIcon, ButtonText} from '#/components/Button'
+import * as Dialog from '#/components/Dialog'
+import * as TextField from '#/components/forms/TextField'
+import {
+  ArrowLeft_Stroke2_Corner0_Rounded as ArrowLeftIcon,
+  ArrowRight_Stroke2_Corner0_Rounded as ArrowRightIcon,
+} from '#/components/icons/Arrow'
+import {CheckThick_Stroke2_Corner0_Rounded as CheckIcon} from '#/components/icons/Check'
+import {Globe_Stroke2_Corner0_Rounded as GlobeIcon} from '#/components/icons/Globe'
+import {InlineLinkText} from '#/components/Link'
+import {Loader} from '#/components/Loader'
+import {Text} from '#/components/Typography'
+import {IS_WEB} from '#/env'
+
+type Page = 'search' | 'contact' | 'overview' | 'polling' | 'done'
+
+type PaymentMethod = 'stripe' | 'paypal' | 'nowpayments'
+
+const PENDING_CHECKOUT_KEY = 'eurosky.marque.pendingCheckout'
+
+type PendingCheckout = {
+  orderId: string
+  domain: string
+  checkoutUrl: string
+}
+
+function readPendingCheckout(): PendingCheckout | null {
+  if (!IS_WEB || typeof window === 'undefined') return null
+  try {
+    const value: unknown = JSON.parse(
+      window.localStorage.getItem(PENDING_CHECKOUT_KEY) ?? 'null',
+    )
+    if (
+      value &&
+      typeof value === 'object' &&
+      'orderId' in value &&
+      'domain' in value &&
+      'checkoutUrl' in value &&
+      typeof value.orderId === 'string' &&
+      typeof value.domain === 'string' &&
+      typeof value.checkoutUrl === 'string'
+    ) {
+      return {
+        orderId: value.orderId,
+        domain: value.domain,
+        checkoutUrl: value.checkoutUrl,
+      }
+    }
+  } catch {}
+  return null
+}
+
+function readCallbackOrderId(): string | null {
+  if (!IS_WEB || typeof window === 'undefined') return null
+  return new URLSearchParams(window.location.search).get('order')
+}
+
+function writePendingCheckout(value: PendingCheckout | null) {
+  if (!IS_WEB || typeof window === 'undefined') return
+  if (value) {
+    window.localStorage.setItem(PENDING_CHECKOUT_KEY, JSON.stringify(value))
+  } else {
+    window.localStorage.removeItem(PENDING_CHECKOUT_KEY)
+  }
+}
+
+export function hasPendingDomainCheckout() {
+  return readCallbackOrderId() !== null || readPendingCheckout() !== null
+}
+
+const PAYMENT_METHODS: {value: PaymentMethod; label: string}[] = [
+  {value: 'stripe', label: 'Card'},
+  {value: 'paypal', label: 'PayPal'},
+  {value: 'nowpayments', label: 'Crypto'},
+]
+
+const STATE_REQUIRED_COUNTRIES = new Set([
+  'US',
+  'CA',
+  'AU',
+  'IE',
+  'GB',
+  'IT',
+  'BR',
+  'JP',
+  'MX',
+])
+
+type Provisioned = {
+  domain: string
+  nameServers: string[]
+  registeredAt?: string
+  expiresAt?: string
+}
+
+export function BuyDomainDialog({
+  control,
+}: {
+  control: Dialog.DialogControlProps
+}) {
+  return (
+    <Dialog.Outer control={control}>
+      <Dialog.Handle />
+      <BuyDomainDialogInner />
+    </Dialog.Outer>
+  )
+}
+
+function BuyDomainDialogInner() {
+  const control = Dialog.useDialogContext()
+  const {t: l} = useLingui()
+
+  const cancelButton = () => (
+    <Button
+      label={l`Cancel`}
+      onPress={() => control.close()}
+      size="small"
+      color="primary"
+      variant="ghost"
+      style={[a.rounded_full]}>
+      <ButtonText style={[a.text_md]}>
+        <Trans>Cancel</Trans>
+      </ButtonText>
+    </Button>
+  )
+
+  return (
+    <Dialog.ScrollableInner
+      label={l`Buy a domain`}
+      header={
+        <Dialog.Header renderLeft={cancelButton}>
+          <Dialog.HeaderText>
+            <Trans>Buy a domain</Trans>
+          </Dialog.HeaderText>
+        </Dialog.Header>
+      }
+      contentContainerStyle={[a.pt_0, a.px_0]}>
+      <View style={[a.px_xl, a.pt_lg]}>
+        <BuyDomainFlow />
+      </View>
+    </Dialog.ScrollableInner>
+  )
+}
+
+export function BuyDomainFlow() {
+  const openUrl = useOpenUrl()
+  const pendingCheckout = useMemo(readPendingCheckout, [])
+  const callbackOrderId = useMemo(readCallbackOrderId, [])
+  const resumedCheckout =
+    pendingCheckout?.orderId === callbackOrderId || !callbackOrderId
+      ? pendingCheckout
+      : null
+  const initialOrderId = callbackOrderId ?? resumedCheckout?.orderId ?? null
+
+  const [page, setPage] = useState<Page>(initialOrderId ? 'polling' : 'search')
+  const [name, setName] = useState('')
+  const [selectedDomain, setSelectedDomain] = useState<string | null>(
+    resumedCheckout?.domain ?? null,
+  )
+  const [selectedPrice, setSelectedPrice] = useState<number | null>(null)
+  const [orderId, setOrderId] = useState<string | null>(initialOrderId)
+  const [checkoutUrl, setCheckoutUrl] = useState<string | null>(
+    resumedCheckout?.checkoutUrl ?? null,
+  )
+  const [provisioned, setProvisioned] = useState<Provisioned | null>(null)
+  const [registrant, setRegistrant] = useState<Registrant | null>(null)
+
+  return (
+    <View style={[a.gap_md]}>
+      {page === 'search' && (
+        <SearchPage
+          name={name}
+          setName={setName}
+          selectedDomain={selectedDomain}
+          setSelectedDomain={(d, price) => {
+            setSelectedDomain(d)
+            setSelectedPrice(price ?? null)
+          }}
+          onContinue={() => setPage('contact')}
+        />
+      )}
+      {page === 'contact' && selectedDomain && (
+        <ContactPage
+          domain={selectedDomain}
+          initialRegistrant={registrant}
+          onBack={() => setPage('search')}
+          onContinue={r => {
+            setRegistrant(r)
+            setPage('overview')
+          }}
+        />
+      )}
+      {page === 'overview' && selectedDomain && registrant && (
+        <OverviewPage
+          domain={selectedDomain}
+          price={selectedPrice}
+          registrant={registrant}
+          onBack={() => setPage('contact')}
+          onCheckout={(id, url) => {
+            const pending = {
+              orderId: id,
+              domain: selectedDomain,
+              checkoutUrl: url,
+            }
+            setOrderId(id)
+            setCheckoutUrl(url)
+            setPage('polling')
+            // Same-tab navigation avoids popup blockers after the async call.
+            if (IS_WEB && typeof window !== 'undefined') {
+              writePendingCheckout(pending)
+              window.location.href = url
+            } else {
+              openUrl(url)
+            }
+          }}
+        />
+      )}
+      {page === 'polling' && orderId && (
+        <PollingPage
+          orderId={orderId}
+          domain={selectedDomain}
+          checkoutUrl={checkoutUrl}
+          onProvisioned={p => {
+            writePendingCheckout(null)
+            setProvisioned(p)
+            setPage('done')
+          }}
+          onBack={() => {
+            writePendingCheckout(null)
+            setOrderId(null)
+            setCheckoutUrl(null)
+            setPage(selectedDomain && registrant ? 'overview' : 'search')
+          }}
+        />
+      )}
+      {page === 'done' && provisioned && (
+        <DonePage
+          provisioned={provisioned}
+          onReset={() => {
+            writePendingCheckout(null)
+            setOrderId(null)
+            setProvisioned(null)
+            setCheckoutUrl(null)
+            setSelectedDomain(null)
+            setSelectedPrice(null)
+            setName('')
+            setPage('search')
+          }}
+        />
+      )}
+    </View>
+  )
+}
+
+function useOpenUrl() {
+  const openLink = useOpenLink()
+  return (url: string) => openLink(url)
+}
+
+function SearchPage({
+  name,
+  setName,
+  selectedDomain,
+  setSelectedDomain,
+  onContinue,
+}: {
+  name: string
+  setName: (n: string) => void
+  selectedDomain: string | null
+  setSelectedDomain: (d: string | null, price?: number) => void
+  onContinue: () => void
+}) {
+  const {t: l} = useLingui()
+  const t = useTheme()
+  const inputRef = useRef<TextInput | null>(null)
+  const wasFocusedRef = useRef(false)
+  const {
+    data: pricing,
+    isError: pricingError,
+    error: pricingErr,
+  } = useMarquePricingQuery()
+  const tlds = pricing?.tlds ?? []
+
+  const [debouncedName, setDebouncedName] = useState('')
+  useEffect(() => {
+    const handle = setTimeout(() => setDebouncedName(name), 350)
+    return () => clearTimeout(handle)
+  }, [name])
+
+  const {
+    data,
+    isFetching,
+    isFetchingNextPage,
+    hasNextPage,
+    isError: searchError,
+    error: searchErr,
+    fetchNextPage,
+  } = useDomainSearchQuery(debouncedName, tlds, {enabled: tlds.length > 0})
+  const results = useMemo(
+    () =>
+      (data?.pages ?? []).flatMap(page =>
+        [...page.results].sort((a, b) => {
+          const av = a.available ? 0 : 1
+          const bv = b.available ? 0 : 1
+          return av - bv
+        }),
+      ),
+    [data],
+  )
+
+  const anyAvailable = results.some(r => r.available)
+
+  // Some browsers move focus when the results scroller mounts.
+  useEffect(() => {
+    if (results.length > 0 && wasFocusedRef.current) {
+      inputRef.current?.focus()
+    }
+  }, [results.length])
+
+  const onNameChange = (text: string) => {
+    setName(text)
+    setSelectedDomain(null)
+  }
+
+  const rowPrice = (r: AvailabilityResult): number | undefined =>
+    r.isPremium && r.premiumPrice != null ? r.premiumPrice : r.price
+
+  return (
+    <>
+      <Text style={[a.leading_snug]}>
+        <Trans>
+          Buy a domain and we’ll set it up as your handle automatically. No DNS
+          configuration needed. Powered by Marque.
+        </Trans>
+      </Text>
+
+      <View>
+        <TextField.LabelText>
+          <Trans>Find a domain</Trans>
+        </TextField.LabelText>
+        <TextField.Root>
+          <TextField.Icon icon={GlobeIcon} />
+          <Dialog.Input
+            label={l`Find a domain`}
+            placeholder={l`e.g. alice`}
+            defaultValue={name}
+            onChangeText={onNameChange}
+            inputRef={inputRef}
+            onFocus={() => (wasFocusedRef.current = true)}
+            onBlur={() => (wasFocusedRef.current = false)}
+            autoCapitalize="none"
+            autoCorrect={false}
+            autoComplete="off"
+            keyboardType="url"
+          />
+        </TextField.Root>
+      </View>
+
+      {isFetching && results.length === 0 && (
+        <View style={[a.flex_row, a.align_center, a.gap_sm, a.py_sm]}>
+          <Loader size="sm" />
+          <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
+            <Trans>Checking availability…</Trans>
+          </Text>
+        </View>
+      )}
+
+      {pricingError && (
+        <Admonition type="error">{cleanError(pricingErr)}</Admonition>
+      )}
+      {searchError && (
+        <Admonition type="error">{cleanError(searchErr)}</Admonition>
+      )}
+
+      {results.length > 0 && (
+        <ScrollView
+          style={[
+            {maxHeight: 320},
+            web({
+              scrollbarWidth: 'thin',
+              scrollbarColor: `${t.palette.contrast_100} transparent`,
+            }),
+          ]}
+          contentContainerStyle={[a.gap_xs]}
+          keyboardShouldPersistTaps="handled">
+          {!anyAvailable && (
+            <Text style={[a.text_sm, t.atoms.text_contrast_medium, a.py_xs]}>
+              <Trans>
+                No domains available for “{name}”. Try another name.
+              </Trans>
+            </Text>
+          )}
+          {results.map(r => (
+            <DomainResultRow
+              key={r.domain}
+              result={r}
+              selected={selectedDomain === r.domain}
+              onSelect={() =>
+                setSelectedDomain(
+                  r.available ? r.domain : null,
+                  r.available ? rowPrice(r) : undefined,
+                )
+              }
+            />
+          ))}
+        </ScrollView>
+      )}
+
+      {hasNextPage && (
+        <Button
+          label={l`Show more extensions`}
+          variant="outline"
+          color="secondary"
+          size="small"
+          disabled={isFetchingNextPage}
+          onPress={() => void fetchNextPage()}>
+          {isFetchingNextPage ? (
+            <ButtonIcon icon={Loader} />
+          ) : (
+            <ButtonText>
+              <Trans>Show more extensions</Trans>
+            </ButtonText>
+          )}
+        </Button>
+      )}
+
+      <Button
+        label={l`Continue`}
+        variant="solid"
+        size="large"
+        color={selectedDomain ? 'primary' : 'secondary'}
+        disabled={!selectedDomain}
+        onPress={onContinue}>
+        <ButtonText>
+          <Trans>Continue</Trans>
+        </ButtonText>
+        <ButtonIcon icon={ArrowRightIcon} position="right" />
+      </Button>
+    </>
+  )
+}
+
+function DomainResultRow({
+  result,
+  selected,
+  onSelect,
+}: {
+  result: AvailabilityResult
+  selected: boolean
+  onSelect: () => void
+}) {
+  const {t: l} = useLingui()
+  const t = useTheme()
+  const available = !!result.available
+  const price =
+    result.isPremium && result.premiumPrice != null
+      ? result.premiumPrice
+      : result.price
+  const showRenew =
+    available &&
+    !result.isPremium &&
+    result.renewPrice != null &&
+    price != null &&
+    result.renewPrice !== price
+
+  // Button forwards tabIndex at runtime, but its public props omit the type.
+  const ResultButton = Button as React.ComponentType<
+    React.ComponentProps<typeof Button> & {tabIndex?: number}
+  >
+
+  return (
+    <ResultButton
+      label={result.domain}
+      variant="outline"
+      color={selected ? 'primary' : available ? 'secondary' : 'secondary'}
+      size="small"
+      shape="rectangular"
+      disabled={!available}
+      onPress={onSelect}
+      tabIndex={-1}
+      style={[
+        a.w_full,
+        !available && {opacity: 0.5},
+        selected && {backgroundColor: t.palette.primary_50},
+      ]}>
+      <View style={[a.flex_row, a.align_center, a.justify_between, a.flex_1]}>
+        <View style={[a.flex_row, a.align_center, a.gap_sm]}>
+          {available ? (
+            <CheckIcon
+              fill={selected ? t.palette.primary_500 : t.palette.positive_500}
+              size="xs"
+            />
+          ) : null}
+          <Text style={[a.text_md]}>{result.domain}</Text>
+          {result.isPremium && available && (
+            <Text
+              style={[
+                a.text_xs,
+                selected ? t.atoms.text : t.atoms.text_contrast_medium,
+              ]}>
+              <Trans>Premium</Trans>
+            </Text>
+          )}
+        </View>
+        <View style={[a.align_end]}>
+          <Text
+            style={[
+              a.text_md,
+              a.font_semi_bold,
+              !available && t.atoms.text_contrast_low,
+            ]}>
+            {available
+              ? price != null
+                ? showRenew
+                  ? `$${price}`
+                  : `$${price}/yr`
+                : l`Available`
+              : l`Taken`}
+          </Text>
+          {showRenew && (
+            <Text style={[a.text_xs, t.atoms.text_contrast_medium]}>
+              <Trans>renews ${result.renewPrice}/yr</Trans>
+            </Text>
+          )}
+        </View>
+      </View>
+    </ResultButton>
+  )
+}
+
+function ContactPage({
+  domain,
+  initialRegistrant,
+  onBack,
+  onContinue,
+}: {
+  domain: string
+  initialRegistrant: Registrant | null
+  onBack: () => void
+  onContinue: (r: Registrant) => void
+}) {
+  const {t: l} = useLingui()
+  const t = useTheme()
+
+  const [firstName, setFirstName] = useState(initialRegistrant?.firstName ?? '')
+  const [lastName, setLastName] = useState(initialRegistrant?.lastName ?? '')
+  const [email, setEmail] = useState(initialRegistrant?.email ?? '')
+  const [phoneCountryCode, setPhoneCountryCode] = useState(
+    initialRegistrant?.phoneCountryCode ?? '',
+  )
+  const [phoneSubscriber, setPhoneSubscriber] = useState(
+    initialRegistrant?.phoneSubscriber ?? '',
+  )
+  const [street, setStreet] = useState(initialRegistrant?.street ?? '')
+  const [city, setCity] = useState(initialRegistrant?.city ?? '')
+  const [zipcode, setZipcode] = useState(initialRegistrant?.zipcode ?? '')
+  const [country, setCountry] = useState(initialRegistrant?.country ?? '')
+  const [region, setRegion] = useState(initialRegistrant?.state ?? '')
+  const [nationalId, setNationalId] = useState(
+    initialRegistrant?.passportNumber ??
+      initialRegistrant?.socialSecurityNumber ??
+      '',
+  )
+  const [companyRegistrationNumber, setCompanyRegistrationNumber] = useState(
+    initialRegistrant?.companyRegistrationNumber ?? '',
+  )
+  const [taxIdType, setTaxIdType] = useState(initialRegistrant?.taxIdType ?? '')
+  const [taxIdValue, setTaxIdValue] = useState(
+    initialRegistrant?.taxIdValue ?? '',
+  )
+  const {
+    data: requirements,
+    isLoading: requirementsLoading,
+    isError: requirementsError,
+  } = useMarqueRequirementsQuery(domain)
+  const normalizedCountry = country.trim().toUpperCase()
+  const stateRequired = STATE_REQUIRED_COUNTRIES.has(normalizedCountry)
+
+  const registrantValid =
+    !!firstName.trim() &&
+    !!lastName.trim() &&
+    !!email.trim() &&
+    !!phoneCountryCode.trim() &&
+    !!phoneSubscriber.trim() &&
+    !!street.trim() &&
+    !!city.trim() &&
+    !!zipcode.trim() &&
+    normalizedCountry.length === 2 &&
+    (!stateRequired || !!region.trim()) &&
+    (!requirements?.passportNumberRequired || !!nationalId.trim()) &&
+    (!requirements?.companyRegistrationNumberRequired ||
+      !!companyRegistrationNumber.trim()) &&
+    (!requirements?.taxNumberRequired || !!taxIdValue.trim()) &&
+    !requirementsLoading &&
+    !requirementsError
+
+  const onSubmit = () => {
+    if (!registrantValid) return
+    onContinue({
+      firstName,
+      lastName,
+      email,
+      phoneCountryCode,
+      phoneSubscriber,
+      street,
+      city,
+      zipcode,
+      country: normalizedCountry,
+      state: region || undefined,
+      passportNumber: nationalId || undefined,
+      socialSecurityNumber: nationalId || undefined,
+      companyRegistrationNumber: companyRegistrationNumber || undefined,
+      taxIdType: taxIdType || undefined,
+      taxIdValue: taxIdValue || undefined,
+    })
+  }
+
+  return (
+    <>
+      <View style={[a.flex_row, a.align_center, a.gap_sm]}>
+        <Button
+          label={l`Back`}
+          onPress={onBack}
+          size="small"
+          color="secondary"
+          variant="ghost">
+          <ButtonIcon icon={ArrowLeftIcon} position="left" />
+          <ButtonText>
+            <Trans>Back</Trans>
+          </ButtonText>
+        </Button>
+        <Text style={[a.text_md, t.atoms.text_contrast_medium]}>
+          <Trans>Registering {domain}</Trans>
+        </Text>
+      </View>
+
+      <Text style={[a.leading_snug]}>
+        <Trans>
+          These details are sent to the registrar to register the domain in your
+          name. We don’t store them.
+        </Trans>
+      </Text>
+
+      <ScrollView
+        style={[
+          {maxHeight: 320},
+          web({
+            scrollbarWidth: 'thin',
+            scrollbarColor: `${t.palette.contrast_100} transparent`,
+          }),
+        ]}
+        contentContainerStyle={[a.gap_md]}
+        keyboardShouldPersistTaps="handled">
+        <TextFieldRow
+          label={l`First name`}
+          value={firstName}
+          onChange={setFirstName}
+        />
+        <TextFieldRow
+          label={l`Last name`}
+          value={lastName}
+          onChange={setLastName}
+        />
+        <TextFieldRow
+          label={l`Email`}
+          value={email}
+          onChange={setEmail}
+          keyboardType="email-address"
+          autoCapitalize="none"
+        />
+        <View style={[a.flex_row, a.gap_sm]}>
+          <View style={[a.flex_1]}>
+            <TextFieldRow
+              label={l`Country code`}
+              value={phoneCountryCode}
+              onChange={setPhoneCountryCode}
+              placeholder={l`+1`}
+              keyboardType="phone-pad"
+            />
+          </View>
+          <View style={[a.flex_1, {flex: 2}]}>
+            <TextFieldRow
+              label={l`Phone`}
+              value={phoneSubscriber}
+              onChange={setPhoneSubscriber}
+              keyboardType="phone-pad"
+            />
+          </View>
+        </View>
+        <TextFieldRow label={l`Street`} value={street} onChange={setStreet} />
+        <View style={[a.flex_row, a.gap_sm]}>
+          <View style={[a.flex_1]}>
+            <TextFieldRow label={l`City`} value={city} onChange={setCity} />
+          </View>
+          <View style={[a.flex_1]}>
+            <TextFieldRow
+              label={l`Postal code`}
+              value={zipcode}
+              onChange={setZipcode}
+            />
+          </View>
+        </View>
+        <View style={[a.flex_row, a.gap_sm]}>
+          <View style={[a.flex_1]}>
+            <TextFieldRow
+              label={l`Country (2 letters)`}
+              value={country}
+              onChange={setCountry}
+              placeholder={l`US`}
+              autoCapitalize="characters"
+            />
+          </View>
+          <View style={[a.flex_1]}>
+            <TextFieldRow
+              label={
+                stateRequired
+                  ? l`State / Province`
+                  : l`State / Province (optional)`
+              }
+              value={region}
+              onChange={setRegion}
+              placeholder={stateRequired ? l`Required` : l`Optional`}
+            />
+          </View>
+        </View>
+        {requirements?.passportNumberRequired && (
+          <TextFieldRow
+            label={l`National ID / passport number`}
+            value={nationalId}
+            onChange={setNationalId}
+          />
+        )}
+        {requirements?.companyRegistrationNumberRequired && (
+          <TextFieldRow
+            label={l`Company registration number`}
+            value={companyRegistrationNumber}
+            onChange={setCompanyRegistrationNumber}
+          />
+        )}
+        {requirements?.taxNumberRequired && (
+          <>
+            <TextFieldRow
+              label={l`Tax ID type (optional)`}
+              value={taxIdType}
+              onChange={setTaxIdType}
+              placeholder={l`Optional`}
+            />
+            <TextFieldRow
+              label={l`Tax / VAT ID`}
+              value={taxIdValue}
+              onChange={setTaxIdValue}
+            />
+          </>
+        )}
+      </ScrollView>
+
+      {requirementsLoading && (
+        <View style={[a.flex_row, a.align_center, a.gap_sm]}>
+          <Loader size="sm" />
+          <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
+            <Trans>Loading registry requirements…</Trans>
+          </Text>
+        </View>
+      )}
+      {requirementsError && (
+        <Admonition type="error">
+          <Trans>
+            We couldn’t load this domain’s registry requirements. Please try
+            again.
+          </Trans>
+        </Admonition>
+      )}
+
+      <Button
+        label={l`Next`}
+        variant="solid"
+        size="large"
+        color={registrantValid ? 'primary' : 'secondary'}
+        disabled={!registrantValid}
+        onPress={onSubmit}>
+        <ButtonText>
+          <Trans>Next</Trans>
+        </ButtonText>
+        <ButtonIcon icon={ArrowRightIcon} position="right" />
+      </Button>
+    </>
+  )
+}
+
+function OverviewPage({
+  domain,
+  price,
+  registrant,
+  onBack,
+  onCheckout,
+}: {
+  domain: string
+  price: number | null
+  registrant: Registrant
+  onBack: () => void
+  onCheckout: (orderId: string, checkoutUrl: string) => void
+}) {
+  const {t: l} = useLingui()
+  const t = useTheme()
+  const createCheckout = useCreateCheckoutMutation()
+  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>('stripe')
+
+  const years = 1
+  const lineTotal = price ?? 0
+  const total = lineTotal * years
+
+  const onSubmit = () => {
+    createCheckout.mutate(
+      {
+        items: [{domain, years, whoisPrivacy: true}],
+        registrant,
+        paymentMethod,
+      },
+      {
+        onSuccess: res => onCheckout(res.orderId, res.checkoutUrl),
+      },
+    )
+  }
+
+  return (
+    <>
+      <View style={[a.flex_row, a.align_center, a.gap_sm]}>
+        <Button
+          label={l`Back`}
+          onPress={onBack}
+          size="small"
+          color="secondary"
+          variant="ghost">
+          <ButtonIcon icon={ArrowLeftIcon} position="left" />
+          <ButtonText>
+            <Trans>Back</Trans>
+          </ButtonText>
+        </Button>
+        <Text style={[a.text_md, t.atoms.text_contrast_medium]}>
+          <Trans>Review your order</Trans>
+        </Text>
+      </View>
+
+      <View
+        style={[
+          a.gap_sm,
+          a.p_md,
+          a.rounded_md,
+          t.atoms.bg_contrast_25,
+          a.border,
+          t.atoms.border_contrast_low,
+        ]}>
+        <SummaryRow label={l`Domain`} value={domain} />
+        <SummaryRow
+          label={l`Registration`}
+          value={l`${years} year${years > 1 ? 's' : ''}`}
+        />
+        <SummaryRow label={l`WHOIS privacy`} value={l`Included`} muted />
+        <View style={[a.border_t, t.atoms.border_contrast_low, a.mt_xs]} />
+        <SummaryRow
+          label={l`Total due`}
+          value={price != null ? `$${total}` : l`—`}
+          bold
+        />
+      </View>
+
+      <View style={[a.gap_xs]}>
+        <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
+          <Trans>Payment method</Trans>
+        </Text>
+        <View style={[a.flex_row, a.gap_sm]}>
+          {PAYMENT_METHODS.map(m => {
+            const selected = paymentMethod === m.value
+            return (
+              <Button
+                key={m.value}
+                label={m.label}
+                size="small"
+                variant={selected ? 'solid' : 'outline'}
+                color={selected ? 'primary' : 'secondary'}
+                onPress={() => setPaymentMethod(m.value)}>
+                <ButtonText>
+                  <Trans>{m.label}</Trans>
+                </ButtonText>
+              </Button>
+            )
+          })}
+        </View>
+      </View>
+
+      {createCheckout.isError && (
+        <Animated.View entering={FadeIn} exiting={FadeOut}>
+          <Admonition type="error">
+            {cleanError(createCheckout.error)}
+          </Admonition>
+        </Animated.View>
+      )}
+
+      <Button
+        label={l`Continue to payment`}
+        variant="solid"
+        size="large"
+        color="primary"
+        disabled={createCheckout.isPending}
+        onPress={onSubmit}>
+        {createCheckout.isPending ? (
+          <ButtonIcon icon={Loader} />
+        ) : (
+          <ButtonText>
+            <Trans>Continue to payment</Trans>
+          </ButtonText>
+        )}
+      </Button>
+
+      <Text style={[a.text_xs, a.leading_snug, t.atoms.text_contrast_medium]}>
+        <Trans>
+          You’ll be redirected to the payment provider. We never see your card
+          details. By continuing you agree to Marque’s{' '}
+          <InlineLinkText
+            label={l`Terms of Service`}
+            to="https://marque.at/terms"
+            style={[a.font_semi_bold]}
+            disableMismatchWarning>
+            <Trans>Terms of Service</Trans>
+          </InlineLinkText>{' '}
+          and{' '}
+          <InlineLinkText
+            label={l`Privacy Policy`}
+            to="https://marque.at/privacy"
+            style={[a.font_semi_bold]}
+            disableMismatchWarning>
+            <Trans>Privacy Policy</Trans>
+          </InlineLinkText>
+          .
+        </Trans>
+      </Text>
+    </>
+  )
+}
+
+function SummaryRow({
+  label,
+  value,
+  bold,
+  muted,
+}: {
+  label: string
+  value: string
+  bold?: boolean
+  muted?: boolean
+}) {
+  const t = useTheme()
+  return (
+    <View style={[a.flex_row, a.justify_between, a.align_center]}>
+      <Text
+        style={[
+          a.text_sm,
+          muted && t.atoms.text_contrast_medium,
+          bold && a.font_semi_bold,
+        ]}>
+        {label}
+      </Text>
+      <Text
+        style={[
+          a.text_sm,
+          muted && t.atoms.text_contrast_medium,
+          bold && a.font_semi_bold,
+        ]}>
+        {value}
+      </Text>
+    </View>
+  )
+}
+
+function PollingPage({
+  orderId,
+  domain,
+  checkoutUrl,
+  onProvisioned,
+  onBack,
+}: {
+  orderId: string
+  domain: string | null
+  checkoutUrl: string | null
+  onProvisioned: (p: Provisioned) => void
+  onBack: () => void
+}) {
+  const {t: l} = useLingui()
+  const openUrl = useOpenUrl()
+  const {data: order, isError, error} = useOrderPollingQuery(orderId)
+
+  const item = useMemo(
+    () =>
+      domain ? order?.items.find(i => i.domain === domain) : order?.items[0],
+    [order, domain],
+  )
+  const resolvedDomain = item?.domain ?? domain ?? ''
+  const resolvedCheckoutUrl = checkoutUrl ?? order?.checkoutUrl ?? null
+
+  useEffect(() => {
+    if (order?.status === ORDER_ACTIVE && item?.status === ITEM_ACTIVE) {
+      onProvisioned({
+        domain: item.domain,
+        nameServers: item.nameServers ?? [],
+        registeredAt: item.registeredAt,
+        expiresAt: item.expiresAt,
+      })
+    }
+  }, [order, item, onProvisioned])
+
+  const failed =
+    order?.status === ORDER_FAILED || (item && item.status === 'failed')
+
+  return (
+    <View style={[a.flex_1, a.gap_md, a.justify_center, a.align_center]}>
+      {!failed && (
+        <>
+          <Loader size="xl" />
+          <Text style={[a.text_md, a.text_center, a.leading_snug]}>
+            {order?.status === 'awaitingPayment' ? (
+              <Trans>
+                Complete your payment in the browser, then come back.
+              </Trans>
+            ) : (
+              <Trans>Registering {resolvedDomain}…</Trans>
+            )}
+          </Text>
+          {resolvedCheckoutUrl && (
+            <Button
+              label={l`Pay now`}
+              variant="solid"
+              color="primary"
+              size="large"
+              onPress={() => openUrl(resolvedCheckoutUrl)}>
+              <ButtonText>
+                <Trans>Pay now</Trans>
+              </ButtonText>
+            </Button>
+          )}
+          <Button
+            label={l`Cancel`}
+            variant="ghost"
+            color="secondary"
+            size="small"
+            onPress={onBack}>
+            <ButtonText>
+              <Trans>Cancel</Trans>
+            </ButtonText>
+          </Button>
+        </>
+      )}
+      {failed && (
+        <>
+          <Admonition type="error">
+            {order?.error ||
+              item?.error ||
+              l`The order could not be completed.`}
+          </Admonition>
+          <Button
+            label={l`Back`}
+            variant="solid"
+            color="primary"
+            size="large"
+            onPress={onBack}>
+            <ButtonText>
+              <Trans>Back</Trans>
+            </ButtonText>
+          </Button>
+        </>
+      )}
+      {isError && <Admonition type="error">{cleanError(error)}</Admonition>}
+    </View>
+  )
+}
+
+function DonePage({
+  provisioned,
+  onReset,
+}: {
+  provisioned: Provisioned
+  onReset: () => void
+}) {
+  const {t: l} = useLingui()
+  const t = useTheme()
+  const {currentAccount} = useSession()
+  const pdsClient = usePdsClient()
+  const fetchDid = useFetchDid()
+  const control = Dialog.useDialogContext()
+  const [subdomain, setSubdomain] = useState('')
+  const normalizedSubdomain = subdomain
+    .trim()
+    .toLowerCase()
+    .replace(/^\.+|\.+$/g, '')
+  const handle = normalizedSubdomain
+    ? `${normalizedSubdomain}.${provisioned.domain}`
+    : provisioned.domain
+  const isSubdomainValid =
+    !normalizedSubdomain ||
+    (handle.length <= 253 &&
+      normalizedSubdomain.split('.').every(label => {
+        return (
+          label.length <= 63 && /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label)
+        )
+      }))
+
+  const changeHandle = useUpdateHandleMutation({
+    onSuccess: () => {
+      control.close(() => onReset())
+    },
+  })
+  const finalize = useFinalizeDomainPurchaseMutation({
+    onSuccess: () => {
+      prepareHandle.mutate(handle)
+    },
+  })
+
+  const prepareHandle = useMutation({
+    mutationKey: ['prepare-purchased-marque-handle', handle],
+    mutationFn: async (nextHandle: string) => {
+      if (!currentAccount?.did) throw new Error('Not authenticated')
+      const result = await ensureMarqueAtprotoRecord(
+        pdsClient,
+        currentAccount.did,
+        nextHandle,
+      )
+      if (result === 'conflict') throw new PurchasedHandleDnsConflictError()
+      if (result === 'not-owned') throw new Error('Domain is not Marque-owned')
+
+      // Wait out transient negative DNS caches before calling updateHandle.
+      let lastError: unknown
+      for (let attempt = 0; attempt < 12; attempt++) {
+        if (attempt > 0) {
+          await new Promise(resolve => setTimeout(resolve, 5000))
+        }
+        try {
+          const did = await fetchDid(nextHandle)
+          if (did !== currentAccount.did) throw new Error('DID mismatch')
+          return nextHandle
+        } catch (error) {
+          lastError = error
+        }
+      }
+      throw new PurchasedHandleDnsPendingError(lastError)
+    },
+    onSuccess(nextHandle) {
+      changeHandle.mutate({handle: nextHandle})
+    },
+  })
+
+  const onSetHandle = () => {
+    if (!isSubdomainValid) return
+    finalize.mutate({
+      domain: provisioned.domain,
+      nameServers: provisioned.nameServers,
+      registeredAt: provisioned.registeredAt,
+      expiresAt: provisioned.expiresAt,
+    })
+  }
+
+  // Only offer step-up for the explicit handle-scope failure.
+  const handleErrorMessage =
+    changeHandle.error instanceof Error ? changeHandle.error.message : ''
+  const needsScopeUpgrade =
+    changeHandle.isError &&
+    currentAccount?.isOauthSession &&
+    handleErrorMessage.includes('identity:handle')
+
+  if (needsScopeUpgrade) {
+    return (
+      <HandleScopeUpgrade
+        onError={() => {
+          changeHandle.reset()
+        }}
+      />
+    )
+  }
+
+  return (
+    <View style={[a.flex_1, a.gap_md, a.justify_center, a.align_center]}>
+      <View
+        style={[
+          {height: 40, width: 40},
+          a.rounded_full,
+          a.align_center,
+          a.justify_center,
+          {backgroundColor: t.palette.positive_500},
+        ]}>
+        <CheckIcon fill={t.palette.white} size="md" />
+      </View>
+      <Text style={[a.text_lg, a.font_bold, a.text_center]}>
+        <Trans>{provisioned.domain} is registered!</Trans>
+      </Text>
+      <Text style={[a.text_md, a.text_center, a.leading_snug]}>
+        <Trans>
+          Choose the root domain or add a subdomain, then we’ll publish its AT
+          Protocol DNS record and wait for it to resolve.
+        </Trans>
+      </Text>
+
+      <View style={[a.w_full]}>
+        <TextField.LabelText>
+          <Trans>Subdomain (optional)</Trans>
+        </TextField.LabelText>
+        <TextField.Root isInvalid={!isSubdomainValid}>
+          <TextField.Icon icon={GlobeIcon} />
+          <Dialog.Input
+            label={l`Subdomain`}
+            placeholder={l`Leave blank for the root domain`}
+            defaultValue={subdomain}
+            onChangeText={value => {
+              setSubdomain(value)
+              prepareHandle.reset()
+              changeHandle.reset()
+            }}
+            autoCapitalize="none"
+            autoCorrect={false}
+          />
+          <TextField.SuffixText
+            label={`.${provisioned.domain}`}
+            style={[{maxWidth: '45%'}]}>
+            .{provisioned.domain}
+          </TextField.SuffixText>
+        </TextField.Root>
+        <Text style={[a.mt_sm, a.text_sm, t.atoms.text_contrast_medium]}>
+          <Trans>
+            Your handle will be{' '}
+            <Text style={[a.font_semi_bold]}>@{handle}</Text>
+          </Trans>
+        </Text>
+      </View>
+
+      {(finalize.isError || prepareHandle.isError || changeHandle.isError) && (
+        <Admonition type="error">
+          {prepareHandle.error instanceof PurchasedHandleDnsPendingError ? (
+            <Trans>
+              The DNS record was created, but public resolvers can’t see it yet.
+              Wait a few minutes, then try again.
+            </Trans>
+          ) : prepareHandle.error instanceof PurchasedHandleDnsConflictError ? (
+            <Trans>
+              This handle already has an AT Protocol DNS record for a different
+              account.
+            </Trans>
+          ) : (
+            cleanError(
+              finalize.error ?? prepareHandle.error ?? changeHandle.error,
+            )
+          )}
+        </Admonition>
+      )}
+
+      <Button
+        label={l`Set as my handle`}
+        variant="solid"
+        size="large"
+        color="primary"
+        disabled={
+          !isSubdomainValid ||
+          finalize.isPending ||
+          prepareHandle.isPending ||
+          changeHandle.isPending
+        }
+        onPress={onSetHandle}
+        style={[a.w_full]}>
+        {finalize.isPending ||
+        prepareHandle.isPending ||
+        changeHandle.isPending ? (
+          <ButtonIcon icon={Loader} />
+        ) : (
+          <ButtonText>
+            <Trans>Set as my handle</Trans>
+          </ButtonText>
+        )}
+      </Button>
+
+      <Button
+        label={l`Not now`}
+        variant="ghost"
+        color="secondary"
+        size="large"
+        onPress={onReset}>
+        <ButtonText>
+          <Trans>Not now</Trans>
+        </ButtonText>
+      </Button>
+    </View>
+  )
+}
+
+class PurchasedHandleDnsConflictError extends Error {
+  constructor() {
+    super('Conflicting AT Protocol DNS record')
+    this.name = 'PurchasedHandleDnsConflictError'
+  }
+}
+
+class PurchasedHandleDnsPendingError extends Error {
+  constructor(cause: unknown) {
+    super('AT Protocol DNS record has not propagated', {cause})
+    this.name = 'PurchasedHandleDnsPendingError'
+  }
+}
+
+function HandleScopeUpgrade({onError}: {onError: () => void}) {
+  const {t: l} = useLingui()
+  const {currentAccount} = useSession()
+  const [isRedirecting, setIsRedirecting] = useState(false)
+  const [redirectError, setRedirectError] = useState<string | undefined>(
+    undefined,
+  )
+
+  const onUpgrade = async () => {
+    if (!currentAccount?.did) return
+    setRedirectError(undefined)
+    setIsRedirecting(true)
+    try {
+      await oauthUpgradeForHandle(
+        currentAccount.did,
+        IS_WEB && typeof window !== 'undefined'
+          ? window.location.href
+          : undefined,
+      )
+    } catch {
+      setIsRedirecting(false)
+      setRedirectError(
+        l`Your server does not support changing your handle from this app.`,
+      )
+    }
+  }
+
+  return (
+    <View style={[a.gap_md]}>
+      {redirectError ? (
+        <Admonition type="error">{redirectError}</Admonition>
+      ) : (
+        <Admonition type="warning">
+          <Trans>
+            Your session needs an extra permission to change your handle.
+          </Trans>
+        </Admonition>
+      )}
+      <Text style={[a.text_md, a.leading_snug]}>
+        <Trans>
+          You’ll be sent to your server to approve the permission, then brought
+          back here to try again.
+        </Trans>
+      </Text>
+      <Button
+        label={l`Continue`}
+        variant="solid"
+        color="primary"
+        size="large"
+        disabled={isRedirecting}
+        onPress={() => void onUpgrade()}>
+        {isRedirecting ? (
+          <ButtonIcon icon={Loader} />
+        ) : (
+          <ButtonText>
+            <Trans>Continue</Trans>
+          </ButtonText>
+        )}
+      </Button>
+      <Button
+        label={l`Cancel`}
+        variant="ghost"
+        color="secondary"
+        size="large"
+        onPress={onError}>
+        <ButtonText>
+          <Trans>Cancel</Trans>
+        </ButtonText>
+      </Button>
+    </View>
+  )
+}
+
+function TextFieldRow({
+  label,
+  value,
+  onChange,
+  placeholder,
+  keyboardType,
+  autoCapitalize,
+}: {
+  label: string
+  value: string
+  onChange: (v: string) => void
+  placeholder?: string
+  keyboardType?: 'default' | 'email-address' | 'phone-pad'
+  autoCapitalize?: 'none' | 'characters' | 'sentences' | 'words'
+}) {
+  const {t: l} = useLingui()
+  return (
+    <View>
+      <TextField.LabelText>{label}</TextField.LabelText>
+      <TextField.Root>
+        <Dialog.Input
+          label={label}
+          placeholder={placeholder ?? l`Required`}
+          defaultValue={value}
+          onChangeText={onChange}
+          keyboardType={keyboardType ?? 'default'}
+          autoCapitalize={autoCapitalize ?? 'words'}
+        />
+      </TextField.Root>
+    </View>
+  )
+}

--- a/src/screens/Settings/components/ChangeHandleDialog.tsx
+++ b/src/screens/Settings/components/ChangeHandleDialog.tsx
@@ -1,5 +1,5 @@
 import {useCallback, useMemo, useState} from 'react'
-import {View} from 'react-native'
+import {ScrollView, View} from 'react-native'
 import Animated, {
   FadeIn,
   FadeOut,
@@ -15,6 +15,7 @@ import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
 import {useMutation, useQueryClient} from '@tanstack/react-query'
 
+import {ensureMarqueAtprotoRecord} from '#/lib/api/marque'
 import {HITSLOP_10, urls} from '#/lib/constants'
 import {cleanError} from '#/lib/strings/errors'
 import {
@@ -24,10 +25,11 @@ import {
 } from '#/lib/strings/handles'
 import {logger} from '#/logger'
 import {useFetchDid, useUpdateHandleMutation} from '#/state/queries/handle'
+import {useMarqueDomainsQuery} from '#/state/queries/marque'
 import {RQKEY as RQKEY_PROFILE} from '#/state/queries/profile'
 import {useServiceQuery} from '#/state/queries/service'
 import {useCurrentAccountProfile} from '#/state/queries/useCurrentAccountProfile'
-import {useSession, useSessionApi} from '#/state/session'
+import {usePdsClient, useSession, useSessionApi} from '#/state/session'
 import {oauthUpgradeForHandle} from '#/state/session/oauth-web-client'
 import {ErrorScreen} from '#/view/com/util/error/ErrorScreen'
 import {atoms as a, native, useBreakpoints, useTheme} from '#/alf'
@@ -48,6 +50,7 @@ import {Loader} from '#/components/Loader'
 import {Text} from '#/components/Typography'
 import {useSimpleVerificationState} from '#/components/verification'
 import {type com} from '#/lexicons'
+import {BuyDomainFlow, hasPendingDomainCheckout} from './BuyDomainDialog'
 import {CopyButton} from './CopyButton'
 
 export function ChangeHandleDialog({
@@ -76,40 +79,53 @@ function ChangeHandleDialogInner() {
     refetch,
   } = useServiceQuery(currentAccount?.service ?? '')
 
-  const [page, setPage] = useState<'provided-handle' | 'own-handle'>(
-    'provided-handle',
-  )
+  const [page, setPage] = useState<
+    'provided-handle' | 'own-handle' | 'buy-domain'
+  >(hasPendingDomainCheckout() ? 'buy-domain' : 'provided-handle')
 
-  const cancelButton = useCallback(
+  const leftButton = useCallback(
     () => (
       <Button
-        label={_(msg`Cancel`)}
-        onPress={() => control.close()}
+        label={page === 'buy-domain' ? _(msg`Back`) : _(msg`Cancel`)}
+        onPress={() =>
+          page === 'buy-domain' ? setPage('provided-handle') : control.close()
+        }
         size="small"
         color="primary"
         variant="ghost"
         style={[a.rounded_full]}>
+        {page === 'buy-domain' && (
+          <ButtonIcon icon={ArrowLeftIcon} position="left" />
+        )}
         <ButtonText style={[a.text_md]}>
-          <Trans>Cancel</Trans>
+          {page === 'buy-domain' ? <Trans>Back</Trans> : <Trans>Cancel</Trans>}
         </ButtonText>
       </Button>
     ),
-    [control, _],
+    [control, page, _],
   )
 
   return (
     <Dialog.ScrollableInner
-      label={_(msg`Change Handle`)}
+      label={
+        page === 'buy-domain' ? _(msg`Buy a domain`) : _(msg`Change Handle`)
+      }
       header={
-        <Dialog.Header renderLeft={cancelButton}>
+        <Dialog.Header renderLeft={leftButton}>
           <Dialog.HeaderText>
-            <Trans>Change Handle</Trans>
+            {page === 'buy-domain' ? (
+              <Trans>Buy a domain</Trans>
+            ) : (
+              <Trans>Change Handle</Trans>
+            )}
           </Dialog.HeaderText>
         </Dialog.Header>
       }
       contentContainerStyle={[a.pt_0, a.px_0]}>
       <View style={[a.flex_1, a.pt_lg, a.px_xl]}>
-        {serviceInfoError ? (
+        {page === 'buy-domain' ? (
+          <BuyDomainFlow />
+        ) : serviceInfoError ? (
           <ErrorScreen
             title={_(msg`Oops!`)}
             message={_(msg`There was an issue fetching your service info`)}
@@ -126,6 +142,7 @@ function ChangeHandleDialogInner() {
                 <ProvidedHandlePage
                   serviceInfo={serviceInfo}
                   goToOwnHandle={() => setPage('own-handle')}
+                  goToBuyDomain={() => setPage('buy-domain')}
                 />
               </Animated.View>
             ) : (
@@ -240,9 +257,11 @@ function isBenignHandleValidationError(error: unknown): boolean {
 function ProvidedHandlePage({
   serviceInfo,
   goToOwnHandle,
+  goToBuyDomain,
 }: {
   serviceInfo: com.atproto.server.describeServer.$OutputBody
   goToOwnHandle: () => void
+  goToBuyDomain: () => void
 }) {
   const {_} = useLingui()
   const [subdomain, setSubdomain] = useState('')
@@ -405,6 +424,17 @@ function ProvidedHandlePage({
             </ButtonText>
             <ButtonIcon icon={ArrowRightIcon} position="right" />
           </Button>
+          <Button
+            label={_(msg`Buy a domain`)}
+            variant="outline"
+            color="primary"
+            size="large"
+            onPress={goToBuyDomain}>
+            <ButtonText>
+              <Trans>Buy a domain</Trans>
+            </ButtonText>
+            <ButtonIcon icon={ArrowRightIcon} position="right" />
+          </Button>
         </Animated.View>
       </View>
     </LayoutAnimationConfig>
@@ -415,12 +445,37 @@ function OwnHandlePage({goToServiceHandle}: {goToServiceHandle: () => void}) {
   const {_} = useLingui()
   const t = useTheme()
   const {currentAccount} = useSession()
-  const [dnsPanel, setDNSPanel] = useState(true)
+  const [verificationMethod, setVerificationMethod] = useState<
+    'dns' | 'file' | 'marque'
+  >('dns')
+  const [selectedMarqueDomain, setSelectedMarqueDomain] = useState('')
+  const [marqueSubdomain, setMarqueSubdomain] = useState('')
+  const [manualDomain, setManualDomain] = useState('')
   const [domain, setDomain] = useState('')
   const control = Dialog.useDialogContext()
   const {partialRefreshSession} = useSessionApi()
+  const pdsClient = usePdsClient()
   const fetchDid = useFetchDid()
   const queryClient = useQueryClient()
+  const {data: marqueDomains = []} = useMarqueDomainsQuery()
+
+  const normalizedMarqueSubdomain = marqueSubdomain
+    .trim()
+    .toLowerCase()
+    .replace(/^\.+|\.+$/g, '')
+  const marqueHandle = selectedMarqueDomain
+    ? normalizedMarqueSubdomain
+      ? `${normalizedMarqueSubdomain}.${selectedMarqueDomain}`
+      : selectedMarqueDomain
+    : ''
+  const isMarqueSubdomainValid =
+    !normalizedMarqueSubdomain ||
+    (marqueHandle.length <= 253 &&
+      normalizedMarqueSubdomain.split('.').every(label => {
+        return (
+          label.length <= 63 && /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label)
+        )
+      }))
 
   const {
     mutate: changeHandle,
@@ -448,11 +503,29 @@ function OwnHandlePage({goToServiceHandle}: {goToServiceHandle: () => void}) {
   } = useMutation<true, Error | DidMismatchError>({
     mutationKey: ['verify-handle', domain],
     mutationFn: async () => {
-      const did = await fetchDid(domain)
-      if (did !== currentAccount?.did) {
-        throw new DidMismatchError(did)
+      if (!currentAccount?.did) throw new Error('Not authenticated')
+      const marqueResult = await ensureMarqueAtprotoRecord(
+        pdsClient,
+        currentAccount.did,
+        domain,
+      )
+      if (marqueResult === 'conflict') throw new MarqueDnsConflictError()
+
+      const attempts = marqueResult === 'created' ? 5 : 1
+      let lastError: unknown
+      for (let attempt = 0; attempt < attempts; attempt++) {
+        if (attempt > 0) {
+          await new Promise(resolve => setTimeout(resolve, attempt * 1000))
+        }
+        try {
+          const did = await fetchDid(domain)
+          if (did !== currentAccount.did) throw new DidMismatchError(did)
+          return true
+        } catch (error) {
+          lastError = error
+        }
       }
-      return true
+      throw lastError
     },
   })
 
@@ -481,7 +554,13 @@ function OwnHandlePage({goToServiceHandle}: {goToServiceHandle: () => void}) {
       {verifyError && (
         <Animated.View entering={FadeIn} exiting={FadeOut}>
           <Admonition type="error">
-            {verifyError instanceof DidMismatchError ? (
+            {verifyError instanceof MarqueDnsConflictError ? (
+              <Trans>
+                This Marque domain already has an AT Protocol DNS record for a
+                different account. Manage its DNS records in Marque before
+                trying again.
+              </Trans>
+            ) : verifyError instanceof DidMismatchError ? (
               <Trans>
                 Wrong DID returned from server. Received: {verifyError.did}
               </Trans>
@@ -494,31 +573,144 @@ function OwnHandlePage({goToServiceHandle}: {goToServiceHandle: () => void}) {
       <Animated.View
         layout={native(LinearTransition)}
         style={[a.flex_1, a.gap_md, a.overflow_hidden]}>
-        <View>
-          <TextField.LabelText>
-            <Trans>Enter the domain you want to use</Trans>
-          </TextField.LabelText>
-          <TextField.Root>
-            <TextField.Icon icon={AtIcon} />
-            <Dialog.Input
-              label={_(msg`New handle`)}
-              placeholder={_(msg`e.g. alice.com`)}
-              editable={!isPending}
-              defaultValue={domain}
-              onChangeText={text => {
-                setDomain(text)
-                resetVerification()
-              }}
-              autoCapitalize="none"
-              autoCorrect={false}
-            />
-          </TextField.Root>
-        </View>
+        {verificationMethod !== 'marque' ? (
+          <View>
+            <TextField.LabelText>
+              <Trans>Enter the domain you want to use</Trans>
+            </TextField.LabelText>
+            <TextField.Root>
+              <TextField.Icon icon={AtIcon} />
+              <Dialog.Input
+                label={_(msg`New handle`)}
+                placeholder={_(msg`e.g. alice.com`)}
+                editable={!isPending}
+                defaultValue={manualDomain}
+                onChangeText={text => {
+                  setManualDomain(text)
+                  setDomain(text)
+                  resetVerification()
+                }}
+                autoCapitalize="none"
+                autoCorrect={false}
+              />
+            </TextField.Root>
+          </View>
+        ) : (
+          <View style={[a.gap_sm]}>
+            <TextField.LabelText>
+              <Trans>Enter the domain you want to use</Trans>
+            </TextField.LabelText>
+            <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
+              <Trans>Choose one of your Marque domains</Trans>
+            </Text>
+            <ScrollView
+              style={[{maxHeight: 190}]}
+              contentContainerStyle={[a.gap_xs]}
+              keyboardShouldPersistTaps="handled">
+              {marqueDomains.map(item => {
+                const selected = selectedMarqueDomain === item.domain
+                return (
+                  <Button
+                    key={item.domain}
+                    label={_(msg`Use ${item.domain}`)}
+                    variant="outline"
+                    color={selected ? 'primary' : 'secondary'}
+                    size="small"
+                    shape="rectangular"
+                    onPress={() => {
+                      setSelectedMarqueDomain(item.domain)
+                      setDomain(
+                        normalizedMarqueSubdomain
+                          ? `${normalizedMarqueSubdomain}.${item.domain}`
+                          : item.domain,
+                      )
+                      resetVerification()
+                    }}
+                    style={[
+                      a.w_full,
+                      selected && {backgroundColor: t.palette.primary_50},
+                    ]}>
+                    <View
+                      style={[
+                        a.flex_row,
+                        a.flex_1,
+                        a.align_center,
+                        a.justify_between,
+                        a.gap_sm,
+                      ]}>
+                      <Text style={[a.text_md, a.font_semi_bold]}>
+                        {item.domain}
+                      </Text>
+                      {selected && (
+                        <CheckIcon fill={t.palette.primary_500} size="xs" />
+                      )}
+                    </View>
+                  </Button>
+                )
+              })}
+            </ScrollView>
+            {selectedMarqueDomain && (
+              <View style={[a.mt_sm]}>
+                <TextField.LabelText>
+                  <Trans>Add a subdomain (optional)</Trans>
+                </TextField.LabelText>
+                <TextField.Root isInvalid={!isMarqueSubdomainValid}>
+                  <TextField.Icon icon={AtIcon} />
+                  <Dialog.Input
+                    label={_(msg`Marque subdomain`)}
+                    placeholder={_(msg`Leave blank to use the root domain`)}
+                    defaultValue={marqueSubdomain}
+                    onChangeText={value => {
+                      setMarqueSubdomain(value)
+                      const normalized = value
+                        .trim()
+                        .toLowerCase()
+                        .replace(/^\.+|\.+$/g, '')
+                      setDomain(
+                        normalized
+                          ? `${normalized}.${selectedMarqueDomain}`
+                          : selectedMarqueDomain,
+                      )
+                      resetVerification()
+                    }}
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                  />
+                  <TextField.SuffixText
+                    label={`.${selectedMarqueDomain}`}
+                    style={[{maxWidth: '45%'}]}>
+                    .{selectedMarqueDomain}
+                  </TextField.SuffixText>
+                </TextField.Root>
+              </View>
+            )}
+            {!isMarqueSubdomainValid && (
+              <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
+                <Trans>
+                  Use letters, numbers, hyphens, or dots. Labels can’t start or
+                  end with a hyphen.
+                </Trans>
+              </Text>
+            )}
+            {marqueHandle && (
+              <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
+                <Trans>
+                  Your handle will be{' '}
+                  <Text style={[a.font_semi_bold]}>@{marqueHandle}</Text>
+                </Trans>
+              </Text>
+            )}
+          </View>
+        )}
         <SegmentedControl.Root
           label={_(msg`Choose domain verification method`)}
           type="tabs"
-          value={dnsPanel ? 'dns' : 'file'}
-          onChange={values => setDNSPanel(values === 'dns')}>
+          value={verificationMethod}
+          onChange={value => {
+            setVerificationMethod(value)
+            setDomain(value === 'marque' ? marqueHandle : manualDomain)
+            resetVerification()
+          }}>
           <SegmentedControl.Item value="dns" label={_(msg`DNS Panel`)}>
             <SegmentedControl.ItemText>
               <Trans>DNS Panel</Trans>
@@ -529,8 +721,13 @@ function OwnHandlePage({goToServiceHandle}: {goToServiceHandle: () => void}) {
               <Trans>No DNS Panel</Trans>
             </SegmentedControl.ItemText>
           </SegmentedControl.Item>
+          {marqueDomains.length > 0 && (
+            <SegmentedControl.Item value="marque" label="Marque">
+              <SegmentedControl.ItemText>Marque</SegmentedControl.ItemText>
+            </SegmentedControl.Item>
+          )}
         </SegmentedControl.Root>
-        {dnsPanel ? (
+        {verificationMethod === 'dns' ? (
           <>
             <Text>
               <Trans>Add the following DNS record to your domain:</Trans>
@@ -596,7 +793,7 @@ function OwnHandlePage({goToServiceHandle}: {goToServiceHandle: () => void}) {
               <Text style={[a.text_md]}>_atproto.{domain}</Text>
             </View>
           </>
-        ) : (
+        ) : verificationMethod === 'file' ? (
           <>
             <Text>
               <Trans>Upload a text file to:</Trans>
@@ -632,6 +829,13 @@ function OwnHandlePage({goToServiceHandle}: {goToServiceHandle: () => void}) {
               <ButtonIcon icon={CopyIcon} />
             </CopyButton>
           </>
+        ) : (
+          <Text>
+            <Trans>
+              We’ll add the AT Protocol DNS record to this Marque domain for
+              you.
+            </Trans>
+          </Text>
         )}
       </Animated.View>
       {isVerified && (
@@ -659,14 +863,19 @@ function OwnHandlePage({goToServiceHandle}: {goToServiceHandle: () => void}) {
           label={
             isVerified
               ? _(msg`Update to ${domain}`)
-              : dnsPanel
+              : verificationMethod === 'dns'
                 ? _(msg`Verify DNS Record`)
-                : _(msg`Verify Text File`)
+                : verificationMethod === 'file'
+                  ? _(msg`Verify Text File`)
+                  : _(msg`Configure Marque domain`)
           }
           variant="solid"
           size="large"
           color="primary"
-          disabled={domain.trim().length === 0}
+          disabled={
+            domain.trim().length === 0 ||
+            (verificationMethod === 'marque' && !isMarqueSubdomainValid)
+          }
           onPress={() => {
             if (isVerified) {
               changeHandle({handle: domain})
@@ -680,10 +889,12 @@ function OwnHandlePage({goToServiceHandle}: {goToServiceHandle: () => void}) {
             <ButtonText>
               {isVerified ? (
                 <Trans>Update to {domain}</Trans>
-              ) : dnsPanel ? (
+              ) : verificationMethod === 'dns' ? (
                 <Trans>Verify DNS Record</Trans>
-              ) : (
+              ) : verificationMethod === 'file' ? (
                 <Trans>Verify Text File</Trans>
+              ) : (
+                <Trans>Configure domain</Trans>
               )}
             </ButtonText>
           )}
@@ -713,6 +924,13 @@ class DidMismatchError extends Error {
     super('DID mismatch')
     this.name = 'DidMismatchError'
     this.did = did
+  }
+}
+
+class MarqueDnsConflictError extends Error {
+  constructor() {
+    super('Conflicting Marque AT Protocol DNS record')
+    this.name = 'MarqueDnsConflictError'
   }
 }
 

--- a/src/state/queries/marque.ts
+++ b/src/state/queries/marque.ts
@@ -1,0 +1,347 @@
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query'
+
+import {
+  checkAvailability,
+  type CheckoutItem,
+  type CheckoutResponse,
+  createCheckout,
+  findMarqueDomainForHandle,
+  getMarqueDnsRecord,
+  getOrder,
+  getRequirements,
+  ITEM_ACTIVE,
+  listMarqueDomainRecords,
+  listPricing,
+  ORDER_ACTIVE,
+  ORDER_FAILED,
+  putDnsRecord,
+  putDomainRecord,
+  type Registrant,
+  type TldPricing,
+} from '#/lib/api/marque'
+import {logger} from '#/logger'
+import {STALE} from '#/state/queries'
+import {usePdsClient, useSession} from '#/state/session'
+import {IS_WEB} from '#/env'
+
+const marqueQueryKeyRoot = 'marque'
+
+function safeErrorShape(e: unknown) {
+  if (!e || typeof e !== 'object') return String(e)
+  const any = e as Record<string, unknown>
+  const shape: Record<string, unknown> = {
+    name: any.name,
+    message: any.message,
+    stack: typeof any.stack === 'string' ? '[stack]' : undefined,
+    toString: typeof any.toString === 'function' ? '[fn]' : undefined,
+    status: any.status,
+    error: any.error,
+    cause: any.cause ? safeErrorShape(any.cause) : undefined,
+  }
+  return shape
+}
+
+const pricingQueryKey = createKey('pricing')
+const orderQueryKey = (orderId: string) => createKey('order', {orderId})
+const searchQueryKey = (name: string, rankedTlds: string[]) =>
+  createKey('search', {name, tlds: rankedTlds.join(',')})
+
+/** Requirements for the selected registration domain. */
+export function useMarqueRequirementsQuery(domain?: string) {
+  const client = usePdsClient()
+  return useQuery({
+    queryKey: createKey('requirements', {domain: domain ?? ''}),
+    queryFn: () => getRequirements(client, [domain!]).then(r => r.results[0]),
+    enabled: !!domain,
+    staleTime: STALE.MINUTES.FIVE,
+  })
+}
+
+function createKey<T extends Record<string, unknown>>(
+  suffix: string,
+  args?: T,
+) {
+  return [marqueQueryKeyRoot, suffix, args ?? ({} as T)] as const
+}
+
+function checkoutCallbackUrls() {
+  if (IS_WEB && typeof window !== 'undefined' && window.location?.origin) {
+    const origin = window.location.origin
+    return {
+      successUrl: `${origin}/settings/account`,
+      cancelUrl: `${origin}/settings/account`,
+    }
+  }
+  return {
+    successUrl: 'https://bsky.social/',
+    cancelUrl: 'https://bsky.social/',
+  }
+}
+
+/** List offered TLDs and standard pricing. */
+export function useMarquePricingQuery() {
+  const client = usePdsClient()
+  return useQuery({
+    queryKey: pricingQueryKey,
+    queryFn: async () => {
+      try {
+        return await listPricing(client)
+      } catch (error) {
+        logger.error('marque: listPricing failed', {
+          safeMessage: error instanceof Error ? error.message : String(error),
+          raw: safeErrorShape(error),
+        })
+        throw error
+      }
+    },
+    staleTime: STALE.MINUTES.THIRTY,
+  })
+}
+
+/** Cross-check a handle against active `at.marque.domain` records. */
+export function useMarqueManagedDomainQuery(handle?: string) {
+  const client = usePdsClient()
+  const {currentAccount} = useSession()
+  const normalized = handle?.toLowerCase().replace(/^@/, '') ?? ''
+  return useQuery({
+    queryKey: createKey('managed-domain', {
+      did: currentAccount?.did ?? '',
+      handle: normalized,
+    }),
+    queryFn: () =>
+      findMarqueDomainForHandle(client, currentAccount!.did, normalized),
+    enabled: !!currentAccount?.did && !!normalized,
+    staleTime: STALE.MINUTES.FIVE,
+  })
+}
+
+/** Active Marque-owned domains available for use as handles. */
+export function useMarqueDomainsQuery() {
+  const client = usePdsClient()
+  const {currentAccount} = useSession()
+  return useQuery({
+    queryKey: createKey('domains', {did: currentAccount?.did ?? ''}),
+    queryFn: async () => {
+      const domains = await listMarqueDomainRecords(client, currentAccount!.did)
+      return domains
+        .filter(domain => domain.status === 'active')
+        .sort((a, b) => a.domain.localeCompare(b.domain))
+    },
+    enabled: !!currentAccount?.did,
+    staleTime: STALE.MINUTES.FIVE,
+  })
+}
+
+/**
+ * Check live availability and pricing for a candidate domain. Debounced by the
+ * caller (the input component controls when to call). Pass a single domain.
+ */
+export function useCheckAvailabilityMutation() {
+  const client = usePdsClient()
+  return useMutation({
+    mutationFn: (domain: string) =>
+      checkAvailability(client, [domain]).then(r => r.results[0] ?? null),
+    onError(error) {
+      logger.error('marque: checkAvailability failed', {
+        safeMessage: error instanceof Error ? error.message : String(error),
+        raw: safeErrorShape(error),
+      })
+    },
+  })
+}
+
+// Match Marque's first-page/subsequent-page result counts.
+const SEARCH_PAGE_ONE_SIZE = 15
+const SEARCH_PAGE_SIZE = 10
+
+function rankTlds(tlds: TldPricing[], requestedTld?: string): string[] {
+  return [...tlds]
+    .sort((a, b) => {
+      if (requestedTld) {
+        if (a.tld === requestedTld && b.tld !== requestedTld) return -1
+        if (b.tld === requestedTld && a.tld !== requestedTld) return 1
+      }
+      if (!!a.popular !== !!b.popular) return a.popular ? -1 : 1
+      return a.tld < b.tld ? -1 : a.tld > b.tld ? 1 : 0
+    })
+    .map(t => t.tld)
+}
+
+function pageOfTlds(
+  ranked: string[],
+  page: number,
+): {tlds: string[]; next: number | undefined} {
+  let slice: string[]
+  let next: number | undefined
+  if (page <= 1) {
+    slice = ranked.slice(0, SEARCH_PAGE_ONE_SIZE)
+    next = ranked.length > SEARCH_PAGE_ONE_SIZE ? 2 : undefined
+  } else {
+    const start = SEARCH_PAGE_ONE_SIZE + (page - 2) * SEARCH_PAGE_SIZE
+    const end = start + SEARCH_PAGE_SIZE
+    slice = ranked.slice(start, end)
+    next = end < ranked.length ? page + 1 : undefined
+  }
+  return {tlds: slice, next}
+}
+
+export function useDomainSearchQuery(
+  name: string,
+  tlds: TldPricing[],
+  opts?: {enabled?: boolean},
+) {
+  const client = usePdsClient()
+  const {sld, requestedTld} = useMemo(() => {
+    const raw = name.trim().toLowerCase().replace(/\s+/g, '')
+    const dot = raw.indexOf('.')
+    if (dot >= 0) {
+      return {sld: raw.slice(0, dot), requestedTld: raw.slice(dot)}
+    }
+    return {sld: raw, requestedTld: undefined}
+  }, [name])
+  const ranked = useMemo(
+    () => rankTlds(tlds, requestedTld),
+    [tlds, requestedTld],
+  )
+
+  return useInfiniteQuery({
+    queryKey: searchQueryKey(sld, ranked),
+    queryFn: async ({pageParam}) => {
+      const {tlds: pageTlds} = pageOfTlds(ranked, pageParam)
+      const domains = pageTlds.map(tld => `${sld}${tld}`)
+      try {
+        return await checkAvailability(client, domains)
+      } catch (error) {
+        logger.error('marque: domain search failed', {
+          safeMessage: error instanceof Error ? error.message : String(error),
+          page: pageParam,
+          raw: safeErrorShape(error),
+        })
+        throw error
+      }
+    },
+    enabled: (opts?.enabled ?? true) && sld.length > 0,
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, allPages) => {
+      const next = pageOfTlds(ranked, allPages.length + 1)
+      return next.tlds.length > 0 ? allPages.length + 1 : undefined
+    },
+    staleTime: STALE.SECONDS.FIFTEEN,
+  })
+}
+
+/** Validate an order and create a hosted payment checkout. */
+export function useCreateCheckoutMutation() {
+  const client = usePdsClient()
+  return useMutation({
+    mutationFn: (input: {
+      items: CheckoutItem[]
+      registrant: Registrant
+      paymentMethod?: 'stripe' | 'paypal' | 'nowpayments'
+    }): Promise<CheckoutResponse> => {
+      const {successUrl, cancelUrl} = checkoutCallbackUrls()
+      return createCheckout(client, {...input, successUrl, cancelUrl})
+    },
+  })
+}
+
+/**
+ * Poll {@link getOrder} until the order reaches a terminal state
+ * (`provisioned` / `failed`). Returns `null` until polling starts (no orderId).
+ *
+ * Polls every few seconds with backoff. The query is disabled when no orderId
+ * is set, and stops automatically once a terminal state is reached.
+ */
+export function useOrderPollingQuery(orderId: string | null) {
+  const client = usePdsClient()
+  const [tick, setTick] = useState(0)
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const query = useQuery({
+    queryKey: orderQueryKey(orderId ?? ''),
+    queryFn: () => getOrder(client, orderId!),
+    enabled: !!orderId,
+    staleTime: STALE.SECONDS.FIFTEEN,
+  })
+
+  useEffect(() => {
+    if (!orderId) return
+    const status = query.data?.status
+    if (status === ORDER_ACTIVE || status === ORDER_FAILED) return
+
+    const delay = tick < 5 ? 2_000 : 5_000
+    timer.current = setTimeout(() => {
+      setTick(t => t + 1)
+      void query.refetch()
+    }, delay)
+    return () => {
+      if (timer.current) clearTimeout(timer.current)
+    }
+  }, [orderId, query, tick])
+
+  return query
+}
+
+export function useFinalizeDomainPurchaseMutation(opts?: {
+  onSuccess?: (domain: string) => void
+  onError?: (error: Error) => void
+}) {
+  const client = usePdsClient()
+  const queryClient = useQueryClient()
+  const {currentAccount} = useSession()
+
+  return useMutation({
+    mutationFn: async (input: {
+      domain: string
+      nameServers: string[]
+      registeredAt?: string
+      expiresAt?: string
+    }) => {
+      const did = currentAccount?.did
+      if (!did) throw new Error('Not authenticated')
+
+      const domainRef = await putDomainRecord(client, did, input.domain, {
+        status: ITEM_ACTIVE,
+        registeredAt: input.registeredAt,
+        expiresAt: input.expiresAt,
+        nameServers: input.nameServers,
+      })
+
+      if (input.nameServers.length > 0) {
+        const existingDns = await getMarqueDnsRecord(client, did, input.domain)
+        await putDnsRecord(
+          client,
+          did,
+          input.domain,
+          domainRef,
+          existingDns?.records ?? [],
+        )
+      }
+    },
+    onSuccess(_data, variables) {
+      void queryClient.invalidateQueries({queryKey: [marqueQueryKeyRoot]})
+      opts?.onSuccess?.(variables.domain)
+    },
+    onError(error) {
+      logger.error('marque: finalize purchase failed', {
+        safeMessage: error instanceof Error ? error.message : String(error),
+      })
+      opts?.onError?.(error)
+    },
+  })
+}
+
+/** Invalidate all Marque-related queries. */
+export function useInvalidateMarqueQueries() {
+  const queryClient = useQueryClient()
+  return useCallback(
+    () => queryClient.invalidateQueries({queryKey: [marqueQueryKeyRoot]}),
+    [queryClient],
+  )
+}

--- a/src/state/session/oauth-web-callback.ts
+++ b/src/state/session/oauth-web-callback.ts
@@ -8,6 +8,7 @@
  */
 import {type SessionApiContext} from '#/state/session/types'
 import {
+  consumePendingHandleStepUpOrder,
   getWebOAuthClient,
   OAUTH_HANDLE_STEPUP_STATE,
   OAUTH_SIGNUP_STATE,
@@ -86,7 +87,17 @@ export async function tryFinishWebOAuthSignIn(
       // The redirect lands at the site root; rewrite the path before the
       // navigator reads it so web linking resolves to account settings, where
       // the reopen flag reopens the change-handle dialog.
-      window.history.replaceState(null, '', '/settings/account')
+      const pendingOrderUrl = consumePendingHandleStepUpOrder()
+      if (pendingOrderUrl) {
+        const returnUrl = new URL(pendingOrderUrl, window.location.origin)
+        window.history.replaceState(
+          null,
+          '',
+          `${returnUrl.pathname}${returnUrl.search}`,
+        )
+      } else {
+        window.history.replaceState(null, '', '/settings/account')
+      }
     } else {
       // Drop the callback params from the URL.
       window.history.replaceState(null, '', window.location.pathname)

--- a/src/state/session/oauth-web-client.ts
+++ b/src/state/session/oauth-web-client.ts
@@ -325,6 +325,7 @@ export const OAUTH_HANDLE_STEPUP_STATE = 'handle-stepup'
  * (localStorage); the consumer no-ops elsewhere.
  */
 const HANDLE_STEPUP_REOPEN_KEY = '@eurosky/reopen-change-handle'
+const HANDLE_STEPUP_ORDER_KEY = '@eurosky/handle-stepup-order'
 
 /**
  * Re-authorize the CURRENT account with the wider handle scope so the user can
@@ -334,23 +335,33 @@ const HANDLE_STEPUP_REOPEN_KEY = '@eurosky/reopen-change-handle'
  * the callback's `login()` replaces the existing session in place with the
  * upgraded tokens.
  *
+ * `pendingOrderUrl` preserves a buy-domain flow across the redirect.
+ *
  * Redirects on success and never resolves (the page is navigating away).
  * Rejects synchronously if the PDS refuses the granular scope (e.g. a PAR
  * `invalid_scope`), so the caller can explain that this server can't do it.
  */
-export async function oauthUpgradeForHandle(did: string): Promise<void> {
+export async function oauthUpgradeForHandle(
+  did: string,
+  pendingOrderUrl?: string,
+): Promise<void> {
   try {
     window.localStorage.setItem(HANDLE_STEPUP_REOPEN_KEY, '1')
+    if (pendingOrderUrl) {
+      window.localStorage.setItem(HANDLE_STEPUP_ORDER_KEY, pendingOrderUrl)
+    }
   } catch {}
   try {
     await getWebOAuthClient().signIn(did, {
       scope: OAUTH_HANDLE_SCOPE,
+      prompt: 'consent',
       state: OAUTH_HANDLE_STEPUP_STATE,
     })
   } catch (e) {
     // No redirect happened; don't leave the reopen flag set.
     try {
       window.localStorage.removeItem(HANDLE_STEPUP_REOPEN_KEY)
+      window.localStorage.removeItem(HANDLE_STEPUP_ORDER_KEY)
     } catch {}
     throw e
   }
@@ -368,4 +379,16 @@ export function consumePendingHandleStepUp(): boolean {
     }
   } catch {}
   return false
+}
+
+/** Read and clear the buy-domain return URL saved during handle step-up. */
+export function consumePendingHandleStepUpOrder(): string | null {
+  try {
+    const url = window.localStorage.getItem(HANDLE_STEPUP_ORDER_KEY)
+    if (url) {
+      window.localStorage.removeItem(HANDLE_STEPUP_ORDER_KEY)
+      return url
+    }
+  } catch {}
+  return null
 }


### PR DESCRIPTION
Also adds a Marque tab in "I have my own domain" for Marque users, so they can automatically set their handle using their existing domains. This tab only shows up for Marque users.

<table>
  <tr>
    <td>
      <img
        src="https://github.com/user-attachments/assets/5e26acb1-3a84-4455-a765-739138f1dc9d"
        alt="Domain search"
        height="320"
      />
    </td>
    <td>
      <img
        src="https://github.com/user-attachments/assets/114ae8a3-fab3-437e-a8b7-3d1b1b63a9bf"
        alt="Registration complete with an optional subdomain field for the handle"
        height="320"
      />
    </td>
    <td>
      <img
        src="https://github.com/user-attachments/assets/5e7f0964-51e7-4e7f-bae5-206de6af6862"
        alt="Marque tab for automatically setting a handle with an existing domain"
        height="320"
      />
    </td>
  </tr>
</table>