### PR TITLE
embed-player: add plyr.fm album and playlist embeds

### DIFF
--- a/__tests__/lib/string.test.ts
+++ b/__tests__/lib/string.test.ts
@@ -460,6 +460,15 @@ describe('parseEmbedPlayerFromUrl', () => {
     'https://static.klipy.com/ii/abc123/73/ac/someFile.gif',
     'https://static.klipy.com/other/path.gif?hh=200&ww=300',
     'https://static.klipy.com',
+
+    'https://plyr.fm/track/1250',
+    'https://www.plyr.fm/track/1250',
+    'https://plyr.fm/playlist/0d6d5f8e-0c9a-4b2e-9c1a-4f5a2b3c4d5e',
+    'https://plyr.fm/u/artwo.xyz/album/emo-dance-music',
+    'https://plyr.fm/u/artwo.xyz',
+    'https://plyr.fm/u/artwo.xyz/album',
+    'https://plyr.fm/track',
+    'https://plyr.fm/',
   ]
 
   const outputs = [
@@ -879,6 +888,33 @@ describe('parseEmbedPlayerFromUrl', () => {
         width: 300,
         height: 200,
       },
+    },
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+
+    {
+      type: 'plyr_track',
+      source: 'plyr',
+      playerUri: 'https://plyr.fm/embed/track/1250?autoplay=1',
+    },
+    {
+      type: 'plyr_track',
+      source: 'plyr',
+      playerUri: 'https://plyr.fm/embed/track/1250?autoplay=1',
+    },
+    {
+      type: 'plyr_playlist',
+      source: 'plyr',
+      playerUri:
+        'https://plyr.fm/embed/playlist/0d6d5f8e-0c9a-4b2e-9c1a-4f5a2b3c4d5e?autoplay=1',
+    },
+    {
+      type: 'plyr_album',
+      source: 'plyr',
+      playerUri:
+        'https://plyr.fm/embed/album/artwo.xyz/emo-dance-music?autoplay=1',
     },
     undefined,
     undefined,

--- a/src/lib/strings/embed-player.ts
+++ b/src/lib/strings/embed-player.ts
@@ -52,6 +52,8 @@ export type EmbedPlayerType =
   | 'bandcamp_album'
   | 'bandcamp_track'
   | 'plyr_track'
+  | 'plyr_album'
+  | 'plyr_playlist'
 
 export const externalEmbedLabels: Record<EmbedPlayerSource, string> = {
   youtube: 'YouTube',
@@ -113,13 +115,29 @@ export function parseEmbedPlayerFromUrl(
 
   // plyr.fm
   if (urlp.hostname === 'plyr.fm' || urlp.hostname === 'www.plyr.fm') {
-    const [__, type, id] = urlp.pathname.split('/')
+    const [__, type, id, albumSegment, slug] = urlp.pathname.split('/')
 
     if (type === 'track' && id) {
       return {
         type: 'plyr_track',
         source: 'plyr',
         playerUri: `https://plyr.fm/embed/track/${id}?autoplay=1`,
+      }
+    }
+
+    if (type === 'playlist' && id) {
+      return {
+        type: 'plyr_playlist',
+        source: 'plyr',
+        playerUri: `https://plyr.fm/embed/playlist/${id}?autoplay=1`,
+      }
+    }
+
+    if (type === 'u' && id && albumSegment === 'album' && slug) {
+      return {
+        type: 'plyr_album',
+        source: 'plyr',
+        playerUri: `https://plyr.fm/embed/album/${id}/${slug}?autoplay=1`,
       }
     }
   }
@@ -570,6 +588,8 @@ export function getPlayerAspect({
     case 'apple_music_playlist':
     case 'spotify_playlist':
     case 'soundcloud_set':
+    case 'plyr_album':
+    case 'plyr_playlist':
       return {height: 380}
     case 'spotify_song':
       if (width <= 300) {


### PR DESCRIPTION
mu already renders plyr.fm track links as inline players (`plyr_track`). this extends the same source to plyr.fm's two collection types, so an album or playlist link in a post gets a player instead of a link card.

- `https://plyr.fm/u/{handle}/album/{slug}` → `plyr_album` → `https://plyr.fm/embed/album/{handle}/{slug}?autoplay=1`
- `https://plyr.fm/playlist/{id}` → `plyr_playlist` → `https://plyr.fm/embed/playlist/{id}?autoplay=1`

both are 380px tall, the same bucket as `soundcloud_set` / `spotify_album` — plyr.fm's own oEmbed answers 380 for these, and the collection player is a header plus a scrollable track list, so it needs the room a single track doesn't.

<details>
<summary>notes</summary>

- no new source: `plyr` already exists in `embedPlayerSources`, `externalEmbedLabels` and the persisted `externalEmbeds` schema, so users' existing plyr.fm consent applies to collections too.
- `parseEmbedPlayerFromUrl` tests: added the three plyr.fm shapes plus the negatives (`/u/{handle}`, `/u/{handle}/album`, `/track`, `/`) — they fail without the parser change.
- `pnpm test __tests__/lib/string.test.ts`, `pnpm typecheck:web`, `pnpm lint` and prettier are clean.
- opened as a draft from `zzstoatzz/social-app` because github allows one fork per network and this repo shares bluesky-social/social-app's.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)