### PR TITLE
fix: stop gating the whole app on Bluesky's app view being up

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -831,9 +831,6 @@
   "src/lib/react-query.tsx": {
     "typescript/no-explicit-any": {
       "count": 1
-    },
-    "typescript/no-unsafe-member-access": {
-      "count": 1
     }
   },
   "src/lib/routes/links.ts": {

--- a/src/env/common.ts
+++ b/src/env/common.ts
@@ -2,6 +2,7 @@ import {type DidString} from '@atproto/syntax'
 
 import packageJson from '#/../package.json'
 import {BRAND} from '#/config/brand'
+import {OAUTH_SIGNUP_PDS_HOST} from '#/config/oauth'
 
 /**
  * The semver version of the app, as defined in `package.json.`
@@ -102,6 +103,21 @@ export const APPVIEW_SHADOW_DID: string =
  */
 export const CHAT_PROXY_DID: DidString =
   process.env.EXPO_PUBLIC_CHAT_PROXY_DID || 'did:web:api.bsky.chat'
+
+/**
+ * Service whose `/xrpc/_health` decides whether the app considers itself
+ * online (see lib/react-query.tsx). This gates TanStack Query's global
+ * `onlineManager`, so it must point at a service we operate.
+ *
+ * It previously used the Bluesky public AppView. That made an AppView outage
+ * fatal to the whole app: one failed request flipped `onlineManager` offline,
+ * which pauses every query - including authed ones bound for our own AppView -
+ * and recovery was gated on a probe against the very service that was down.
+ * Defaults to the signup PDS because it is first-party and always reachable
+ * when the network is. Override per-deploy with EXPO_PUBLIC_HEALTH_PROBE_SERVICE.
+ */
+export const HEALTH_PROBE_SERVICE: string =
+  process.env.EXPO_PUBLIC_HEALTH_PROBE_SERVICE || OAUTH_SIGNUP_PDS_HOST
 
 /**
  * Metrics API host

--- a/src/lib/react-query.tsx
+++ b/src/lib/react-query.tsx
@@ -12,12 +12,11 @@ import {
   PersistQueryClientProvider,
 } from '@tanstack/react-query-persist-client'
 
-import {PUBLIC_BSKY_SERVICE} from '#/lib/constants'
 import {createPersistedQueryStorage} from '#/lib/persisted-query-storage'
 import {listenNetworkConfirmed, listenNetworkLost} from '#/state/events'
 import {isQueryPersisted} from '#/state/queries/util'
 import * as env from '#/env'
-import {IS_NATIVE, IS_WEB} from '#/env'
+import {HEALTH_PROBE_SERVICE, IS_NATIVE, IS_WEB} from '#/env'
 
 declare global {
   interface Window {
@@ -31,16 +30,20 @@ async function checkIsOnline(): Promise<boolean> {
     setTimeout(() => {
       controller.abort()
     }, 15e3)
-    const res = await fetch(`${PUBLIC_BSKY_SERVICE}/xrpc/_health`, {
+    const res = await fetch(`${HEALTH_PROBE_SERVICE}/xrpc/_health`, {
       cache: 'no-store',
       signal: controller.signal,
     })
-    const json = await res.json()
-    if (json.version) {
-      return true
-    } else {
+    if (!res.ok) {
       return false
     }
+    /*
+     * Parse the body to catch captive portals, which answer 200 with HTML.
+     * Don't require a particular field: `_health` payloads differ by service
+     * (our AppView answers `{}`), so parseable JSON is the signal, not `version`.
+     */
+    await res.json()
+    return true
   } catch (e) {
     return false
   }


### PR DESCRIPTION
## Problem

`checkIsOnline` probed `${PUBLIC_BSKY_SERVICE}/xrpc/_health`. On production that resolves to Bluesky's public AppView, so a Bluesky AppView outage took the whole client down with it:

1. Any failed request emits `network-lost`.
2. That flips TanStack Query's global `onlineManager` offline, which pauses **every** query — including authed ones the PDS would have proxied to our own AppView.
3. The only route back online was a probe against the service that was down.

The app wedged offline and never recovered on its own.

This is not hypothetical — it fired again during the Bluesky AppView wobble on 2026-08-27. `mu.social` went down with it while `api.eurosky.network` stayed up and healthy the whole time.

## Change

- The probe now targets the **signup PDS** (`brand.services.signupPdsHost`, currently `https://eurosky.social`) — a service we operate — and is overridable per deploy with `EXPO_PUBLIC_HEALTH_PROBE_SERVICE`.
- It no longer insists on a `version` field, only on a parseable JSON body. Parsing is what distinguishes a real service from a captive portal answering 200 with HTML; requiring that one key would have silently wedged the app offline against our own AppView, whose `_health` returns `{}`.

## Verification

New default probe target, checked live:

```
$ curl https://eurosky.social/xrpc/_health
{"version":"0.5.10"}          http=200, ~75ms, access-control-allow-origin: *
```

200, parseable JSON, CORS-open from a `staging.mu.social` origin — so the browser `fetch` in `checkIsOnline` succeeds.

## Scope

Three files, no behaviour change beyond the probe target and its success condition. `mu.social` remains on Bluesky's AppView for reads (prod only shadow-mirrors 10% to ours) — this PR does not touch that, it just stops that dependency from being fatal to the entire client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
