### PR TITLE
fix: initialize missing EAS build versions

### DIFF
--- a/scripts/setGitHubOutput.sh
+++ b/scripts/setGitHubOutput.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
-outputIos=$(eas build:version:get -p ios)
-outputAndroid=$(eas build:version:get -p android)
-BSKY_IOS_BUILD_NUMBER=${outputIos#*buildNumber - }
-BSKY_ANDROID_VERSION_CODE=${outputAndroid#*versionCode - }
+set -o errexit
+set -o pipefail
+set -o nounset
 
-echo PACKAGE_VERSION="$(jq -r '.version' package.json)" > "$GITHUB_OUTPUT"
-echo BSKY_IOS_BUILD_NUMBER=$BSKY_IOS_BUILD_NUMBER >> "$GITHUB_OUTPUT"
-echo BSKY_ANDROID_VERSION_CODE=$BSKY_ANDROID_VERSION_CODE >> "$GITHUB_OUTPUT"
+output=$(eas build:version:get -p all --json --non-interactive)
+BSKY_IOS_BUILD_NUMBER=$(jq -r '.buildNumber // 1' <<< "$output")
+BSKY_ANDROID_VERSION_CODE=$(jq -r '.versionCode // 1' <<< "$output")
+
+{
+  echo PACKAGE_VERSION="$(jq -r '.version' package.json)"
+  echo BSKY_IOS_BUILD_NUMBER="$BSKY_IOS_BUILD_NUMBER"
+  echo BSKY_ANDROID_VERSION_CODE="$BSKY_ANDROID_VERSION_CODE"
+} > "$GITHUB_OUTPUT"

--- a/scripts/useBuildNumberEnv.sh
+++ b/scripts/useBuildNumberEnv.sh
@@ -7,14 +7,16 @@ set -o nounset
 # global EAS counters. Production OTA deploys rely on this to target the
 # specific native build they are for, since the counters advance with every
 # testflight build.
+if [ -z "${BSKY_IOS_BUILD_NUMBER:-}" ] || [ -z "${BSKY_ANDROID_VERSION_CODE:-}" ]; then
+  output=$(eas build:version:get -p all --json --non-interactive)
+fi
+
 if [ -z "${BSKY_IOS_BUILD_NUMBER:-}" ]; then
-  outputIos=$(eas build:version:get -p ios)
-  BSKY_IOS_BUILD_NUMBER=${outputIos#*buildNumber - }
+  BSKY_IOS_BUILD_NUMBER=$(jq -r '.buildNumber // 1' <<< "$output")
 fi
 
 if [ -z "${BSKY_ANDROID_VERSION_CODE:-}" ]; then
-  outputAndroid=$(eas build:version:get -p android)
-  BSKY_ANDROID_VERSION_CODE=${outputAndroid#*versionCode - }
+  BSKY_ANDROID_VERSION_CODE=$(jq -r '.versionCode // 1' <<< "$output")
 fi
 
 export BSKY_IOS_BUILD_NUMBER BSKY_ANDROID_VERSION_CODE

--- a/scripts/useBuildNumberEnvWithBump.sh
+++ b/scripts/useBuildNumberEnvWithBump.sh
@@ -3,13 +3,15 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-outputIos=$(eas build:version:get -p ios)
-outputAndroid=$(eas build:version:get -p android)
-currentIosVersion=${outputIos#*buildNumber - }
-currentAndroidVersion=${outputAndroid#*versionCode - }
+output=$(eas build:version:get -p all --json --non-interactive)
+currentIosVersion=$(jq -r '.buildNumber // 0' <<< "$output")
+currentAndroidVersion=$(jq -r '.versionCode // 0' <<< "$output")
 
-BSKY_IOS_BUILD_NUMBER=$((currentIosVersion+1))
-BSKY_ANDROID_VERSION_CODE=$((currentAndroidVersion+1))
+# A new EAS project has no remote versions yet. Starting from zero lets the
+# first platform build use the local default of 1, which EAS then persists as
+# that platform's initial remote version.
+BSKY_IOS_BUILD_NUMBER=$((currentIosVersion + 1))
+BSKY_ANDROID_VERSION_CODE=$((currentAndroidVersion + 1))
 
 bash -c "BSKY_IOS_BUILD_NUMBER=$BSKY_IOS_BUILD_NUMBER BSKY_ANDROID_VERSION_CODE=$BSKY_ANDROID_VERSION_CODE $*"
 


### PR DESCRIPTION
## Summary

- read EAS build versions through the structured JSON output
- default an uninitialized platform to build/version code 1
- keep GitHub outputs valid when only one platform has been initialized

## Context

The first iOS TestFlight run failed before compilation because the new EAS project has no remote versions yet. The old scripts parsed the human-readable `No remote versions are configured` message as an integer.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- shell-script checks with mocked empty and populated EAS version responses
- `git diff --check`